### PR TITLE
Add Amp as an ACP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ At least one supported agent CLI:
 - Claude Code
 - OpenCode
 - Cursor Agent
-- Amp ([`amp-acp`](https://github.com/tao12345666333/amp-acp) 0.9.0 or newer;
-  install or update with `npm install -g amp-acp@latest`, then authenticate with
-  `amp login` or adapter setup). Do not confuse it with the incompatible
+- Amp (first [install the Amp CLI](https://ampcode.com/manual) and authenticate
+  with `amp login`; then install [`amp-acp`](https://github.com/tao12345666333/amp-acp)
+  0.9.0 or newer with `npm install -g amp-acp@latest`. If needed, complete
+  adapter setup with `amp-acp --setup`). Do not confuse it with the incompatible
   `acp-amp` executable. Amp's standard permission mode follows the permissions
   configured in Amp; Dream's full-access mode uses the adapter's `Bypass`
   option. The adapter does not currently expose Dream's read-only Plan mode.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ At least one supported agent CLI:
 - Claude Code
 - OpenCode
 - Cursor Agent
+- Amp ([`amp-acp`](https://github.com/tao12345666333/amp-acp) 0.9.0 or newer;
+  install or update with `npm install -g amp-acp@latest`, then authenticate with
+  `amp login` or adapter setup). Do not confuse it with the incompatible
+  `acp-amp` executable. Amp's standard permission mode follows the permissions
+  configured in Amp; Dream's full-access mode uses the adapter's `Bypass`
+  option. The adapter does not currently expose Dream's read-only Plan mode.
 
 ## Download
 

--- a/electron/api/chat-routes.js
+++ b/electron/api/chat-routes.js
@@ -3,7 +3,7 @@ import { resolvePersistedProjectPath } from "../persisted-state.js";
 import { streamClaudeResponse } from "./chat/claude-stream.js";
 import { streamCodexAppServerResponse } from "./chat/codex-app-server.js";
 import { streamCursorResponse } from "./chat/cursor-stream.js";
-import { streamGrokResponse } from "./chat/grok-stream.js";
+import { streamAmpResponse, streamGrokResponse } from "./chat/grok-stream.js";
 import { streamOpenCodeResponse } from "./chat/opencode-stream.js";
 import { resolveChatPermissionModes } from "./chat/permissions.js";
 import {
@@ -99,6 +99,17 @@ const validateGrokReady = async () => {
   return null;
 };
 
+const validateAmpReady = async () => {
+  if (!(await isCliCommandAvailable("amp-acp"))) {
+    return {
+      message:
+        "Amp ACP adapter is not installed or available on PATH. Install amp-acp, then run `amp login` or complete adapter setup.",
+      status: 400,
+    };
+  }
+  return null;
+};
+
 export const registerChatRoutes = (app) => {
   app.post("/api/chat-title", async (c) => {
     let rawBody;
@@ -139,7 +150,12 @@ export const registerChatRoutes = (app) => {
       if (grokError) {
         return c.text(grokError.message, grokError.status);
       }
-    } else {
+    } else if (provider === "amp") {
+      const ampError = await validateAmpReady();
+      if (ampError) {
+        return c.text(ampError.message, ampError.status);
+      }
+    } else if (provider !== "amp") {
       const claudeError = await validateClaudeReady();
       if (claudeError) {
         return c.text(claudeError.message, claudeError.status);
@@ -298,6 +314,25 @@ export const registerChatRoutes = (app) => {
       }
 
       return streamGrokResponse({
+        abortSignal: c.req.raw.signal,
+        agentMode,
+        codexPermissionMode,
+        messages,
+        model,
+        projectReferencesPrompt,
+        projectPath: resolvedProjectPath,
+        reasoningEffort,
+        remoteConversationId,
+        remoteConversationModel,
+        remoteConversationProjectPath,
+        responseMessageMetadata,
+      });
+    }
+
+    if (provider === "amp") {
+      const ampError = await validateAmpReady();
+      if (ampError) return c.text(ampError.message, ampError.status);
+      return streamAmpResponse({
         abortSignal: c.req.raw.signal,
         agentMode,
         codexPermissionMode,

--- a/electron/api/chat/grok-stream.js
+++ b/electron/api/chat/grok-stream.js
@@ -1,5 +1,10 @@
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import {
+  applyAmpSessionOptions,
+  initializeAmpAcp,
+  spawnAmpAcp,
+} from "../providers/amp-acp.js";
+import {
   authenticateGrokAcp,
   getGrokModelsFromInitializeResult,
   initializeGrokAcp,
@@ -51,14 +56,21 @@ const getFirstString = (...values) => {
 const getDreamToolName = (toolCall) => {
   const kind = String(toolCall?.kind ?? "").toLowerCase();
   const title = String(toolCall?.title ?? "").toLowerCase();
+  const acpToolName = title.split(":", 1)[0].trim();
 
+  if (acpToolName.startsWith("mcp__")) return acpToolName;
   if (["edit", "delete", "move"].includes(kind)) return "writeFile";
   if (kind === "read") return "readFile";
   if (kind === "search") return "searchInFiles";
   if (kind === "execute") return "runCommand";
   if (kind === "fetch") return "webFetch";
+  if (acpToolName === "shell_command") return "runCommand";
+  if (acpToolName === "apply_patch") return "writeFile";
+  if (acpToolName === "read_web_page") return "webFetch";
+  if (acpToolName === "web_search") return "webSearch";
+  if (acpToolName === "finder") return "searchInFiles";
   if (title.includes("todo") || title.includes("plan")) return "command";
-  return "command";
+  return acpToolName || "command";
 };
 
 const normalizeToolInput = (toolName, toolCall) => {
@@ -85,13 +97,72 @@ const normalizeToolInput = (toolName, toolCall) => {
   };
 };
 
+export const parseAcpToolOutput = (value, toolName) => {
+  if (typeof value !== "string" || toolName === "readFile") return value;
+
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      toolName === "skill" &&
+      isRecord(parsed) &&
+      Array.isArray(parsed.content)
+    ) {
+      const text = parsed.content
+        .flatMap((entry) =>
+          entry?.type === "text" && typeof entry.text === "string"
+            ? [entry.text]
+            : [],
+        )
+        .join("\n");
+      if (text) return text;
+    }
+    if (
+      toolName === "webSearch" &&
+      Array.isArray(parsed) &&
+      parsed.length > 0 &&
+      parsed.every(
+        (entry) =>
+          isRecord(entry) &&
+          typeof entry.title === "string" &&
+          typeof entry.url === "string",
+      )
+    ) {
+      return parsed
+        .map((entry) => {
+          const excerpts = Array.isArray(entry.excerpts)
+            ? entry.excerpts.filter((excerpt) => typeof excerpt === "string")
+            : [];
+          return [`[${entry.title}](${entry.url})`, ...excerpts].join("\n\n");
+        })
+        .join("\n\n---\n\n");
+    }
+    if (
+      isRecord(parsed) &&
+      ((toolName === "runCommand" &&
+        (typeof parsed.output === "string" ||
+          typeof parsed.stdout === "string" ||
+          typeof parsed.stderr === "string")) ||
+        (toolName === "writeFile" &&
+          typeof parsed.summary === "string" &&
+          Array.isArray(parsed.files)))
+    ) {
+      return parsed;
+    }
+    return value;
+  } catch {
+    return value;
+  }
+};
+
 const extractToolOutput = (toolCall) => {
-  if (toolCall?.rawOutput !== undefined) return toolCall.rawOutput;
+  if (toolCall?.rawOutput != null) {
+    return parseAcpToolOutput(toolCall.rawOutput, toolCall.toolName);
+  }
   if (!Array.isArray(toolCall?.content)) return null;
 
   const parts = toolCall.content.flatMap((entry) => {
     if (entry?.type === "content" && entry.content?.type === "text") {
-      return [entry.content.text];
+      return [parseAcpToolOutput(entry.content.text, toolCall.toolName)];
     }
     if (entry?.type === "diff") {
       return [
@@ -139,7 +210,7 @@ const shouldLoadRemoteSession = ({
       remoteConversationProjectPath === projectPath,
   );
 
-export const streamGrokResponse = ({
+const streamAcpResponse = ({
   abortSignal,
   agentMode,
   codexPermissionMode,
@@ -152,11 +223,16 @@ export const streamGrokResponse = ({
   remoteConversationModel,
   remoteConversationProjectPath,
   responseMessageMetadata,
+  provider = "grok",
 }) => {
+  const isAmp = provider === "amp";
+  const providerLabel = isAmp ? "Amp" : "Grok Build";
   const stream = createUIMessageStream({
     originalMessages: messages,
     onError: (error) =>
-      error instanceof Error ? error.message : "Grok Build request failed.",
+      error instanceof Error
+        ? error.message
+        : `${providerLabel} request failed.`,
     execute: async ({ writer }) => {
       let connection = null;
       let preparedAttachments = null;
@@ -189,7 +265,7 @@ export const streamGrokResponse = ({
             activeTextId = null;
           }
           if (!activeReasoningId) {
-            activeReasoningId = `grok-reasoning-${Date.now()}`;
+            activeReasoningId = `${provider}-reasoning-${Date.now()}`;
             writer.write({ id: activeReasoningId, type: "reasoning-start" });
           }
           writer.write({
@@ -205,7 +281,7 @@ export const streamGrokResponse = ({
           activeReasoningId = null;
         }
         if (!activeTextId) {
-          activeTextId = `grok-text-${Date.now()}`;
+          activeTextId = `${provider}-text-${Date.now()}`;
           writer.write({ id: activeTextId, type: "text-start" });
         }
         writer.write({ delta, id: activeTextId, type: "text-delta" });
@@ -263,7 +339,7 @@ export const streamGrokResponse = ({
         closeTextParts();
         const toolName = getDreamToolName(merged);
         const input = normalizeToolInput(toolName, merged);
-        const title = merged.title || "Grok tool";
+        const title = merged.title || `${providerLabel} tool`;
         writer.write({
           dynamic: true,
           providerExecuted: true,
@@ -297,11 +373,16 @@ export const streamGrokResponse = ({
         completedToolCalls.add(merged.toolCallId);
         const output = extractToolOutput(merged);
         if (merged.status === "failed") {
+          const outputError =
+            getFirstString(output?.message, output) ||
+            (Array.isArray(output)
+              ? output.filter((entry) => typeof entry === "string").join("\n")
+              : null);
           writer.write({
             dynamic: true,
             errorText:
-              getFirstString(merged.rawOutput?.message, merged.rawOutput) ||
-              `${merged.title || "Grok tool"} failed.`,
+              outputError ||
+              `${merged.title || `${providerLabel} tool`} failed.`,
             providerExecuted: true,
             toolCallId: merged.toolCallId,
             type: "tool-output-error",
@@ -367,7 +448,7 @@ export const streamGrokResponse = ({
             : { outcome: { outcome: "cancelled" } };
         }
 
-        const approvalId = `grok:${sessionId}:${toolCallId}`;
+        const approvalId = `${provider}:${sessionId}:${toolCallId}`;
         writer.write({
           approvalId,
           toolCallId,
@@ -375,7 +456,7 @@ export const streamGrokResponse = ({
         });
         const response = await waitForToolApproval({
           id: approvalId,
-          provider: "grok",
+          provider,
           request: {
             input: toolCall.input,
             options,
@@ -417,17 +498,24 @@ export const streamGrokResponse = ({
       writeMetadata(responseMessageMetadata);
 
       try {
+        if (isAmp && agentMode === "plan") {
+          throw new Error(
+            "Amp ACP does not support Dream's read-only Plan mode. Switch this chat to Build mode.",
+          );
+        }
         preparedAttachments = await prepareCodexPromptAttachments(
           getLatestUserMessage(messages),
         );
         if (stopIfAborted()) return;
-        connection = await spawnGrokAcp({
-          agentMode,
-          codexPermissionMode,
-          cwd: projectPath,
-          model,
-          reasoningEffort,
-        });
+        connection = isAmp
+          ? await spawnAmpAcp({ cwd: projectPath })
+          : await spawnGrokAcp({
+              agentMode,
+              codexPermissionMode,
+              cwd: projectPath,
+              model,
+              reasoningEffort,
+            });
         if (stopIfAborted()) return;
         connection.onNotification = (method, params) => {
           if (method === "session/update") handleSessionUpdate(params);
@@ -436,26 +524,34 @@ export const streamGrokResponse = ({
           if (method === "session/request_permission") {
             return handlePermissionRequest(params);
           }
-          throw new Error(`Unsupported Grok ACP request: ${method}`);
+          throw new Error(
+            `Unsupported ${providerLabel} ACP request: ${method}`,
+          );
         };
 
-        const initializeResult = await initializeGrokAcp(connection);
+        const initializeResult = isAmp
+          ? await initializeAmpAcp(connection)
+          : await initializeGrokAcp(connection);
         if (stopIfAborted()) return;
-        contextWindow = toFiniteNumber(
-          getGrokModelsFromInitializeResult(initializeResult).find(
-            (entry) => entry?.modelId === model,
-          )?._meta?.totalContextTokens,
-        );
-        await authenticateGrokAcp(connection, initializeResult);
+        if (!isAmp) {
+          contextWindow = toFiniteNumber(
+            getGrokModelsFromInitializeResult(initializeResult).find(
+              (entry) => entry?.modelId === model,
+            )?._meta?.totalContextTokens,
+          );
+        }
+        if (!isAmp) await authenticateGrokAcp(connection, initializeResult);
         if (stopIfAborted()) return;
 
-        const shouldLoad = shouldLoadRemoteSession({
-          model,
-          projectPath,
-          remoteConversationId,
-          remoteConversationModel,
-          remoteConversationProjectPath,
-        });
+        const shouldLoad =
+          !isAmp &&
+          shouldLoadRemoteSession({
+            model,
+            projectPath,
+            remoteConversationId,
+            remoteConversationModel,
+            remoteConversationProjectPath,
+          });
         if (shouldLoad && initializeResult?.agentCapabilities?.loadSession) {
           sessionId = remoteConversationId;
           loadingSession = true;
@@ -481,18 +577,28 @@ export const streamGrokResponse = ({
           });
           if (stopIfAborted()) return;
           sessionId = session?.sessionId;
+          if (isAmp && sessionId) {
+            await applyAmpSessionOptions(connection, session, {
+              codexPermissionMode,
+              model,
+              reasoningEffort,
+            });
+            if (stopIfAborted()) return;
+          }
         }
         if (!sessionId) {
-          throw new Error("Grok Build did not return a session id.");
+          throw new Error(`${providerLabel} did not return a session id.`);
         }
 
-        writeMetadata({
-          ...responseMessageMetadata,
-          remoteConversationId: sessionId,
-          remoteConversationModel: model,
-          remoteConversationModelSpeed: "standard",
-          remoteConversationProjectPath: projectPath,
-        });
+        if (!isAmp) {
+          writeMetadata({
+            ...responseMessageMetadata,
+            remoteConversationId: sessionId,
+            remoteConversationModel: model,
+            remoteConversationModelSpeed: "standard",
+            remoteConversationProjectPath: projectPath,
+          });
+        }
 
         const currentTurnAttachments = preparedAttachments?.promptText ?? null;
         const prompt = loadedSession
@@ -506,12 +612,12 @@ export const streamGrokResponse = ({
               currentTurnProjectReferences: projectReferencesPrompt,
               messages,
               projectPath,
-              runtimeDescription:
-                "You are Grok Build running inside the Dream desktop IDE with native project tools.",
+              runtimeDescription: `You are ${providerLabel} running inside the Dream desktop IDE with native project tools.`,
               systemPrompt:
                 "Complete the user's request using the active project when relevant.",
             });
 
+        if (stopIfAborted()) return;
         const promptResult = await connection.request(
           "session/prompt",
           { prompt: [{ text: prompt, type: "text" }], sessionId },
@@ -522,15 +628,25 @@ export const streamGrokResponse = ({
           writeMetadata({
             ...responseMessageMetadata,
             ...(contextWindow ? { contextWindow } : {}),
-            remoteConversationId: sessionId,
-            remoteConversationModel: model,
-            remoteConversationModelSpeed: "standard",
-            remoteConversationProjectPath: projectPath,
+            ...(!isAmp
+              ? {
+                  remoteConversationId: sessionId,
+                  remoteConversationModel: model,
+                  remoteConversationModelSpeed: "standard",
+                  remoteConversationProjectPath: projectPath,
+                }
+              : {}),
             usage,
           });
         }
       } catch (error) {
-        if (!abortSignal?.aborted) throw error;
+        if (!abortSignal?.aborted) {
+          if (connection && sessionId) {
+            connection.notify("session/cancel", { sessionId });
+            await new Promise((resolve) => setTimeout(resolve, 250));
+          }
+          throw error;
+        }
       } finally {
         closeTextParts();
         abortSignal?.removeEventListener("abort", handleAbort);
@@ -542,3 +658,9 @@ export const streamGrokResponse = ({
 
   return createUIMessageStreamResponse({ stream });
 };
+
+export const streamGrokResponse = (options) =>
+  streamAcpResponse({ ...options, provider: "grok" });
+
+export const streamAmpResponse = (options) =>
+  streamAcpResponse({ ...options, provider: "amp" });

--- a/electron/api/chat/grok-stream.test.js
+++ b/electron/api/chat/grok-stream.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseAcpToolOutput } from "./grok-stream.js";
+
+describe("ACP tool output normalization", () => {
+  it("preserves JSON file content for read tools", () => {
+    expect(parseAcpToolOutput("[]", "readFile")).toBe("[]");
+    expect(
+      parseAcpToolOutput('{"stdout":"literal file data"}', "readFile"),
+    ).toBe('{"stdout":"literal file data"}');
+  });
+
+  it("decodes command result envelopes only for command tools", () => {
+    const serialized = '{"output":"done\\n","exitCode":0}';
+    expect(parseAcpToolOutput(serialized, "runCommand")).toEqual({
+      exitCode: 0,
+      output: "done\n",
+    });
+    expect(parseAcpToolOutput(serialized, "mcp__example__read")).toBe(
+      serialized,
+    );
+  });
+
+  it("formats non-empty web search results but preserves empty results", () => {
+    expect(
+      parseAcpToolOutput(
+        '[{"title":"Amp","url":"https://ampcode.com","excerpts":["Manual"]}]',
+        "webSearch",
+      ),
+    ).toBe("[Amp](https://ampcode.com)\n\nManual");
+    expect(parseAcpToolOutput("[]", "webSearch")).toBe("[]");
+  });
+
+  it("preserves malformed and unrecognized JSON output", () => {
+    expect(parseAcpToolOutput("{not-json", "runCommand")).toBe("{not-json");
+    expect(parseAcpToolOutput('{"custom":true}', "unknown")).toBe(
+      '{"custom":true}',
+    );
+  });
+});

--- a/electron/api/chat/schema.js
+++ b/electron/api/chat/schema.js
@@ -16,7 +16,14 @@ export const chatRequestBodySchema = z.object({
     )
     .default([]),
   projectPath: z.string().min(1),
-  provider: z.enum(["openai", "anthropic", "opencode", "cursor", "grok"]),
+  provider: z.enum([
+    "openai",
+    "anthropic",
+    "opencode",
+    "cursor",
+    "grok",
+    "amp",
+  ]),
   agentMode: z.enum(["plan", "build"]).default("build"),
   remoteConversationId: z.string().nullable().optional(),
   remoteConversationModel: z.string().nullable().optional(),
@@ -59,7 +66,14 @@ export const chatTitleRequestBodySchema = z.object({
   fallbackModel: z.string().min(1).optional(),
   projectPath: z.string().min(1),
   promptText: z.string(),
-  provider: z.enum(["openai", "anthropic", "opencode", "cursor", "grok"]),
+  provider: z.enum([
+    "openai",
+    "anthropic",
+    "opencode",
+    "cursor",
+    "grok",
+    "amp",
+  ]),
 });
 
 export const DEFAULT_TOOL_STEP_LIMIT = 8;

--- a/electron/api/chat/title.js
+++ b/electron/api/chat/title.js
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createOpencode } from "@opencode-ai/sdk";
 import { generateText } from "ai";
 import { claudeCode } from "ai-sdk-provider-claude-code";
+import { runAmpPrompt } from "../providers/amp-acp.js";
 import { runGrokPrompt } from "../providers/grok-acp.js";
 import {
   CLAUDE_REASONING_EFFORT_MAP,
@@ -251,6 +252,20 @@ const generateGrokChatTitle = async ({ model, projectPath, promptText }) =>
     }),
   );
 
+const generateAmpChatTitle = async ({ model, projectPath, promptText }) =>
+  sanitizeGeneratedChatTitle(
+    await runAmpPrompt({
+      cwd: projectPath,
+      model,
+      prompt: [
+        CHAT_TITLE_SYSTEM_PROMPT,
+        "",
+        buildChatTitlePrompt(promptText).join("\n"),
+      ].join("\n"),
+      timeoutMs: 60_000,
+    }),
+  );
+
 const parseOpenCodeModel = (model) => {
   const [providerID, ...modelParts] = String(model ?? "").split("/");
   const modelID = modelParts.join("/");
@@ -380,6 +395,18 @@ export const generateChatTitle = async ({
 
   if (provider === "cursor") {
     return generateLocalChatTitle(titlePromptText);
+  }
+
+  if (provider === "amp") {
+    const model = fallbackModel?.trim();
+    if (!model) {
+      return generateLocalChatTitle(titlePromptText);
+    }
+    return generateAmpChatTitle({
+      model,
+      projectPath,
+      promptText: titlePromptText,
+    });
   }
 
   if (provider === "grok") {

--- a/electron/api/project-git/actions.js
+++ b/electron/api/project-git/actions.js
@@ -8,6 +8,7 @@ import {
   resolveCodexCliLaunch,
 } from "../chat/codex-cli-launch.js";
 import { getCodexErrorDetail } from "../chat/codex-prompt.js";
+import { runAmpPrompt } from "../providers/amp-acp.js";
 import {
   getCursorCliSpawnErrorMessage,
   normalizeCursorCliModel,
@@ -559,6 +560,10 @@ const generateAiText = async ({
       model,
       prompt,
     });
+  }
+
+  if (provider === "amp") {
+    return runAmpPrompt({ cwd: projectPath, model, prompt });
   }
 
   return runCodexPrompt({ model, prompt, projectPath });

--- a/electron/api/project-git/schemas.js
+++ b/electron/api/project-git/schemas.js
@@ -93,7 +93,7 @@ export const projectGitCommitMessageRequestSchema = z.object({
   model: nullableTrimmedStringSchema,
   projectPath: z.string().min(1),
   provider: z
-    .enum(["openai", "anthropic", "opencode", "cursor", "grok"])
+    .enum(["openai", "anthropic", "opencode", "cursor", "grok", "amp"])
     .default("openai"),
 });
 
@@ -134,6 +134,6 @@ export const projectGitPullRequestDetailsRequestSchema = z.object({
     .default("create"),
   projectPath: z.string().min(1),
   provider: z
-    .enum(["openai", "anthropic", "opencode", "cursor", "grok"])
+    .enum(["openai", "anthropic", "opencode", "cursor", "grok", "amp"])
     .default("openai"),
 });

--- a/electron/api/provider-routes.js
+++ b/electron/api/provider-routes.js
@@ -113,14 +113,21 @@ export const registerProviderRoutes = (app) => {
                     null,
                   ]
                 : provider === "amp"
-                  ? [null, null, null, null, null, await fetchAmpModels()]
+                  ? [
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      await fetchAmpModels({ force }),
+                    ]
                   : await Promise.all([
                       fetchOpenAiModels({ force }),
                       fetchAnthropicModels({ force }),
                       fetchOpenCodeModels({ force }),
                       fetchCursorModels({ force }),
                       fetchGrokModels({ force }),
-                      fetchAmpModels(),
+                      fetchAmpModels({ force }),
                     ]);
 
     return c.json({

--- a/electron/api/provider-routes.js
+++ b/electron/api/provider-routes.js
@@ -9,6 +9,7 @@ import {
   normalizeClaudeCodeModel,
 } from "./providers/model-options.js";
 import {
+  fetchAmpModels,
   fetchAnthropicModels,
   fetchCursorModels,
   fetchGrokModels,
@@ -36,7 +37,14 @@ export {
 };
 
 const providerUsageLimitsRequestSchema = z.object({
-  provider: z.enum(["openai", "anthropic", "opencode", "cursor", "grok"]),
+  provider: z.enum([
+    "openai",
+    "anthropic",
+    "opencode",
+    "cursor",
+    "grok",
+    "amp",
+  ]),
   projectPath: z.string().optional(),
 });
 
@@ -44,7 +52,7 @@ const providerModelsRequestSchema = z
   .object({
     force: z.boolean().optional(),
     provider: z
-      .enum(["openai", "anthropic", "opencode", "cursor", "grok"])
+      .enum(["openai", "anthropic", "opencode", "cursor", "grok", "amp"])
       .optional(),
   })
   .optional();
@@ -65,24 +73,55 @@ export const registerProviderRoutes = (app) => {
 
     const force = parsed.data?.force ?? false;
     const provider = parsed.data?.provider;
-    const [openai, anthropic, opencode, cursor, grok] =
+    const [openai, anthropic, opencode, cursor, grok, amp] =
       provider === "openai"
-        ? [await fetchOpenAiModels({ force }), null, null, null, null]
+        ? [await fetchOpenAiModels({ force }), null, null, null, null, null]
         : provider === "anthropic"
-          ? [null, await fetchAnthropicModels({ force }), null, null, null]
+          ? [
+              null,
+              await fetchAnthropicModels({ force }),
+              null,
+              null,
+              null,
+              null,
+            ]
           : provider === "opencode"
-            ? [null, null, await fetchOpenCodeModels({ force }), null, null]
+            ? [
+                null,
+                null,
+                await fetchOpenCodeModels({ force }),
+                null,
+                null,
+                null,
+              ]
             : provider === "cursor"
-              ? [null, null, null, await fetchCursorModels({ force }), null]
+              ? [
+                  null,
+                  null,
+                  null,
+                  await fetchCursorModels({ force }),
+                  null,
+                  null,
+                ]
               : provider === "grok"
-                ? [null, null, null, null, await fetchGrokModels({ force })]
-                : await Promise.all([
-                    fetchOpenAiModels({ force }),
-                    fetchAnthropicModels({ force }),
-                    fetchOpenCodeModels({ force }),
-                    fetchCursorModels({ force }),
-                    fetchGrokModels({ force }),
-                  ]);
+                ? [
+                    null,
+                    null,
+                    null,
+                    null,
+                    await fetchGrokModels({ force }),
+                    null,
+                  ]
+                : provider === "amp"
+                  ? [null, null, null, null, null, await fetchAmpModels()]
+                  : await Promise.all([
+                      fetchOpenAiModels({ force }),
+                      fetchAnthropicModels({ force }),
+                      fetchOpenCodeModels({ force }),
+                      fetchCursorModels({ force }),
+                      fetchGrokModels({ force }),
+                      fetchAmpModels(),
+                    ]);
 
     return c.json({
       ...(anthropic ? { anthropic } : {}),
@@ -91,6 +130,7 @@ export const registerProviderRoutes = (app) => {
       ...(openai ? { openai } : {}),
       ...(opencode ? { opencode } : {}),
       ...(grok ? { grok } : {}),
+      ...(amp ? { amp } : {}),
     });
   });
 
@@ -116,11 +156,12 @@ export const registerProviderRoutes = (app) => {
       });
     }
 
-    if (parsed.data.provider === "grok") {
+    if (parsed.data.provider === "grok" || parsed.data.provider === "amp") {
+      const label = parsed.data.provider === "amp" ? "Amp" : "Grok Build";
       return c.json({
-        error: "Grok Build usage limits are unavailable.",
+        error: `${label} usage limits are unavailable.`,
         fetchedAt: new Date().toISOString(),
-        provider: "grok",
+        provider: parsed.data.provider,
         status: "unavailable",
       });
     }

--- a/electron/api/providers/acp-transport.js
+++ b/electron/api/providers/acp-transport.js
@@ -1,0 +1,148 @@
+import readline from "node:readline";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_STDERR_CHARS = 64_000;
+const getFirstNonEmptyString = (...values) =>
+  values.find((value) => typeof value === "string" && value.trim()) ?? null;
+
+export class AcpConnection {
+  constructor(child, label, processLabel = label) {
+    this.child = child;
+    this.label = label;
+    this.closed = false;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.stderr = "";
+    this.onNotification = null;
+    this.onRequest = null;
+    this.reader = readline.createInterface({ input: child.stdout });
+    this.reader.on("line", (line) => this.handleLine(line));
+    child.stderr.on("data", (chunk) => {
+      this.stderr = `${this.stderr}${chunk.toString()}`.slice(
+        -MAX_STDERR_CHARS,
+      );
+    });
+    child.on("error", (error) => this.failPending(error));
+    child.on("close", (code) => {
+      this.closed = true;
+      this.reader.close();
+      this.failPending(
+        new Error(
+          this.stderr.trim() ||
+            (code === 0
+              ? `${label} ACP connection closed.`
+              : `${processLabel} exited with code ${code}.`),
+        ),
+      );
+    });
+  }
+
+  handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (message.id !== undefined && !message.method) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        const detail = getFirstNonEmptyString(
+          message.error.message,
+          message.error.data?.details,
+          message.error.data?.message,
+        );
+        pending.reject(new Error(detail || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result ?? {});
+      }
+      return;
+    }
+
+    if (message.method && message.id !== undefined) {
+      void this.handleIncomingRequest(message);
+      return;
+    }
+
+    if (message.method) {
+      this.onNotification?.(message.method, message.params ?? {});
+    }
+  }
+
+  async handleIncomingRequest(message) {
+    try {
+      if (!this.onRequest) {
+        throw new Error(
+          `Unsupported ${this.label} ACP request: ${message.method}`,
+        );
+      }
+      const result = await this.onRequest(message.method, message.params ?? {});
+      this.write({ jsonrpc: "2.0", id: message.id, result: result ?? {} });
+    } catch (error) {
+      this.write({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32603,
+          message:
+            error instanceof Error
+              ? error.message
+              : `${this.label} ACP request failed.`,
+        },
+      });
+    }
+  }
+
+  write(message) {
+    if (!this.closed && this.child.stdin.writable) {
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+  }
+
+  request(method, params, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
+    if (this.closed) {
+      return Promise.reject(
+        new Error(`${this.label} ACP connection is closed.`),
+      );
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${this.label} ACP ${method} request timed out.`));
+      }, timeoutMs);
+      this.pending.set(id, { reject, resolve, timer });
+      this.write({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  notify(method, params) {
+    this.write({ jsonrpc: "2.0", method, params });
+  }
+
+  failPending(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.reader.close();
+    this.failPending(new Error(`${this.label} ACP connection closed.`));
+    this.child.kill();
+  }
+}
+
+export const initializeAcp = (connection) =>
+  connection.request("initialize", {
+    protocolVersion: 1,
+    clientCapabilities: {},
+  });

--- a/electron/api/providers/acp-transport.js
+++ b/electron/api/providers/acp-transport.js
@@ -138,11 +138,22 @@ export class AcpConnection {
     this.reader.close();
     this.failPending(new Error(`${this.label} ACP connection closed.`));
     this.child.kill();
+    const killTimer = setTimeout(() => {
+      if (this.child.exitCode === null && this.child.signalCode === null) {
+        this.child.kill("SIGKILL");
+      }
+    }, 2_000);
+    killTimer.unref?.();
+    this.child.once("exit", () => clearTimeout(killTimer));
   }
 }
 
-export const initializeAcp = (connection) =>
-  connection.request("initialize", {
+export const initializeAcp = (connection, timeoutMs) => {
+  const params = {
     protocolVersion: 1,
     clientCapabilities: {},
-  });
+  };
+  return timeoutMs === undefined
+    ? connection.request("initialize", params)
+    : connection.request("initialize", params, timeoutMs);
+};

--- a/electron/api/providers/acp-transport.test.js
+++ b/electron/api/providers/acp-transport.test.js
@@ -1,0 +1,45 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AcpConnection } from "./acp-transport.js";
+
+const createChild = () => {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ACP transport cleanup", () => {
+  it("escalates to SIGKILL when a child ignores SIGTERM", () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    const connection = new AcpConnection(child, "Test");
+
+    connection.close();
+    expect(child.kill).toHaveBeenCalledWith();
+
+    vi.advanceTimersByTime(2_000);
+    expect(child.kill).toHaveBeenLastCalledWith("SIGKILL");
+  });
+
+  it("cancels escalation after the child exits", () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    const connection = new AcpConnection(child, "Test");
+
+    connection.close();
+    child.emit("exit", 0);
+    vi.advanceTimersByTime(2_000);
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/api/providers/amp-acp.js
+++ b/electron/api/providers/amp-acp.js
@@ -1,0 +1,220 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveCliCommandPath } from "../shared/cli.js";
+import { AcpConnection, initializeAcp } from "./acp-transport.js";
+
+export const MINIMUM_AMP_ACP_VERSION = "0.9.0";
+const AMP_NO_TOOLS_SETTINGS = {
+  "amp.mcpPermissions": [
+    { action: "reject", matches: { command: "*" } },
+    { action: "reject", matches: { url: "*" } },
+  ],
+  "amp.tools.disable": ["*"],
+};
+
+export const isAmpAcpVersionSupported = (version) => {
+  const match = String(version ?? "").match(
+    /^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/,
+  );
+  if (!match) return false;
+
+  const current = match.slice(1).map(Number);
+  const minimum = MINIMUM_AMP_ACP_VERSION.split(".").map(Number);
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (current[index] > minimum[index]) return true;
+    if (current[index] < minimum[index]) return false;
+  }
+  return true;
+};
+
+export const spawnAmpAcp = async ({ cwd, env } = {}) => {
+  const command = await resolveCliCommandPath("amp-acp");
+  if (!command) {
+    throw new Error(
+      "Amp ACP adapter is not installed or available on PATH. Install amp-acp and run `amp login` or complete adapter setup.",
+    );
+  }
+
+  const child = spawn(command, [], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  return new AcpConnection(child, "Amp");
+};
+
+export const initializeAmpAcp = async (connection) => {
+  const result = await initializeAcp(connection);
+  const name = result?.agentInfo?.name;
+  const version = result?.agentInfo?.version;
+  if (name !== "amp-acp") {
+    throw new Error(
+      `Unexpected ACP adapter ${name || "without an agent name"}; expected amp-acp.`,
+    );
+  }
+  if (!isAmpAcpVersionSupported(version)) {
+    const error = new Error(
+      `amp-acp ${version || "with an unknown version"} is incompatible with current Amp CLI releases. Install amp-acp ${MINIMUM_AMP_ACP_VERSION} or newer.`,
+    );
+    error.ampAcpVersion = typeof version === "string" ? version : null;
+    throw error;
+  }
+  return result;
+};
+
+export const getAmpConfigOptions = (session) =>
+  Array.isArray(session?.configOptions) ? session.configOptions : [];
+
+export const getAmpModelOptions = (session) => {
+  const option = getAmpConfigOptions(session).find(
+    (entry) => entry?.category === "model" && entry?.id === "amp-mode",
+  );
+  return Array.isArray(option?.options)
+    ? option.options
+    : Array.isArray(option?.values)
+      ? option.values
+      : [];
+};
+
+export const getAmpReasoningEfforts = (session) => {
+  const option = getAmpConfigOptions(session).find(
+    (entry) => entry?.category === "thought_level" && entry?.id === "effort",
+  );
+  const values = Array.isArray(option?.options)
+    ? option.options
+    : Array.isArray(option?.values)
+      ? option.values
+      : [];
+
+  return values.flatMap((entry) => {
+    const value =
+      typeof entry === "string" ? entry : (entry?.value ?? entry?.id);
+    return typeof value === "string" && value.trim() ? [value.trim()] : [];
+  });
+};
+
+const optionSupports = (option, value) => {
+  const values = Array.isArray(option?.options)
+    ? option.options
+    : option?.values;
+  return (
+    Array.isArray(values) &&
+    values.some(
+      (entry) =>
+        (typeof entry === "string" ? entry : (entry?.value ?? entry?.id)) ===
+        value,
+    )
+  );
+};
+
+export const applyAmpSessionOptions = async (
+  connection,
+  session,
+  { model, codexPermissionMode, reasoningEffort } = {},
+) => {
+  let options = getAmpConfigOptions(session);
+  const required = [
+    ["amp-mode", model, "model"],
+    [
+      "permission",
+      codexPermissionMode === "full-access" ? "bypass" : "default",
+      "permission mode",
+    ],
+  ];
+
+  for (const [configId, value, label] of required) {
+    const option = options.find((entry) => entry?.id === configId);
+    if (!value || !optionSupports(option, value)) {
+      throw new Error(
+        `Amp ACP does not support the requested ${label} "${value}".`,
+      );
+    }
+
+    const result = await connection.request("session/set_config_option", {
+      sessionId: session.sessionId,
+      configId,
+      value,
+    });
+    if (Array.isArray(result?.configOptions)) {
+      options = result.configOptions;
+    }
+  }
+
+  const effortOption = options.find((entry) => entry?.id === "effort");
+  if (reasoningEffort && optionSupports(effortOption, reasoningEffort)) {
+    await connection.request("session/set_config_option", {
+      sessionId: session.sessionId,
+      configId: "effort",
+      value: reasoningEffort,
+    });
+  }
+};
+
+export const runAmpPrompt = async ({
+  cwd,
+  model,
+  prompt,
+  timeoutMs = 120_000,
+}) => {
+  let connection;
+  let sessionId = null;
+  let settingsDirectory = null;
+  let text = "";
+
+  try {
+    settingsDirectory = await fs.mkdtemp(path.join(tmpdir(), "dream-amp-"));
+    const settingsPath = path.join(settingsDirectory, "settings.json");
+    await fs.writeFile(settingsPath, JSON.stringify(AMP_NO_TOOLS_SETTINGS), {
+      mode: 0o600,
+    });
+    connection = await spawnAmpAcp({
+      cwd,
+      env: { AMP_SETTINGS_FILE: settingsPath },
+    });
+    connection.onNotification = (method, params) => {
+      if (
+        method === "session/update" &&
+        params?.update?.sessionUpdate === "agent_message_chunk"
+      ) {
+        text += params.update.content?.text ?? "";
+      }
+    };
+    connection.onRequest = () => ({ outcome: { outcome: "cancelled" } });
+    await initializeAmpAcp(connection);
+    const session = await connection.request("session/new", {
+      cwd,
+      mcpServers: [],
+    });
+    if (!session?.sessionId)
+      throw new Error("Amp did not return a session id.");
+    sessionId = session.sessionId;
+    await applyAmpSessionOptions(connection, session, {
+      model,
+      codexPermissionMode: "default",
+      reasoningEffort: "high",
+    });
+    await connection.request(
+      "session/prompt",
+      {
+        prompt: [{ text: String(prompt ?? ""), type: "text" }],
+        sessionId,
+      },
+      timeoutMs,
+    );
+    return text.trim();
+  } catch (error) {
+    if (connection && sessionId) {
+      connection.notify("session/cancel", { sessionId });
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw error;
+  } finally {
+    connection?.close();
+    if (settingsDirectory) {
+      await fs.rm(settingsDirectory, { force: true, recursive: true });
+    }
+  }
+};

--- a/electron/api/providers/amp-acp.js
+++ b/electron/api/providers/amp-acp.js
@@ -46,8 +46,8 @@ export const spawnAmpAcp = async ({ cwd, env } = {}) => {
   return new AcpConnection(child, "Amp");
 };
 
-export const initializeAmpAcp = async (connection) => {
-  const result = await initializeAcp(connection);
+export const initializeAmpAcp = async (connection, timeoutMs) => {
+  const result = await initializeAcp(connection, timeoutMs);
   const name = result?.agentInfo?.name;
   const version = result?.agentInfo?.version;
   if (name !== "amp-acp") {
@@ -114,6 +114,7 @@ export const applyAmpSessionOptions = async (
   connection,
   session,
   { model, codexPermissionMode, reasoningEffort } = {},
+  timeoutMs,
 ) => {
   let options = getAmpConfigOptions(session);
   const required = [
@@ -127,17 +128,28 @@ export const applyAmpSessionOptions = async (
 
   for (const [configId, value, label] of required) {
     const option = options.find((entry) => entry?.id === configId);
-    if (!value || !optionSupports(option, value)) {
+    if (!value) {
+      throw new Error(`Amp ACP requires a ${label} selection.`);
+    }
+    if (!optionSupports(option, value)) {
       throw new Error(
         `Amp ACP does not support the requested ${label} "${value}".`,
       );
     }
 
-    const result = await connection.request("session/set_config_option", {
+    const params = {
       sessionId: session.sessionId,
       configId,
       value,
-    });
+    };
+    const result =
+      timeoutMs === undefined
+        ? await connection.request("session/set_config_option", params)
+        : await connection.request(
+            "session/set_config_option",
+            params,
+            timeoutMs,
+          );
     if (Array.isArray(result?.configOptions)) {
       options = result.configOptions;
     }
@@ -145,11 +157,16 @@ export const applyAmpSessionOptions = async (
 
   const effortOption = options.find((entry) => entry?.id === "effort");
   if (reasoningEffort && optionSupports(effortOption, reasoningEffort)) {
-    await connection.request("session/set_config_option", {
+    const params = {
       sessionId: session.sessionId,
       configId: "effort",
       value: reasoningEffort,
-    });
+    };
+    if (timeoutMs === undefined) {
+      await connection.request("session/set_config_option", params);
+    } else {
+      await connection.request("session/set_config_option", params, timeoutMs);
+    }
   }
 };
 
@@ -183,19 +200,28 @@ export const runAmpPrompt = async ({
       }
     };
     connection.onRequest = () => ({ outcome: { outcome: "cancelled" } });
-    await initializeAmpAcp(connection);
-    const session = await connection.request("session/new", {
-      cwd,
-      mcpServers: [],
-    });
+    await initializeAmpAcp(connection, timeoutMs);
+    const session = await connection.request(
+      "session/new",
+      {
+        cwd,
+        mcpServers: [],
+      },
+      timeoutMs,
+    );
     if (!session?.sessionId)
       throw new Error("Amp did not return a session id.");
     sessionId = session.sessionId;
-    await applyAmpSessionOptions(connection, session, {
-      model,
-      codexPermissionMode: "default",
-      reasoningEffort: "high",
-    });
+    await applyAmpSessionOptions(
+      connection,
+      session,
+      {
+        model,
+        codexPermissionMode: "default",
+        reasoningEffort: "high",
+      },
+      timeoutMs,
+    );
     await connection.request(
       "session/prompt",
       {
@@ -214,7 +240,9 @@ export const runAmpPrompt = async ({
   } finally {
     connection?.close();
     if (settingsDirectory) {
-      await fs.rm(settingsDirectory, { force: true, recursive: true });
+      await fs
+        .rm(settingsDirectory, { force: true, recursive: true })
+        .catch(() => {});
     }
   }
 };

--- a/electron/api/providers/amp-acp.test.js
+++ b/electron/api/providers/amp-acp.test.js
@@ -66,6 +66,20 @@ describe("Amp ACP configuration", () => {
     );
   });
 
+  it("uses the caller timeout while initializing", async () => {
+    const request = vi.fn().mockResolvedValue({
+      agentInfo: { name: "amp-acp", version: "0.9.0" },
+    });
+
+    await initializeAmpAcp({ request }, 120_000);
+
+    expect(request).toHaveBeenCalledWith(
+      "initialize",
+      { clientCapabilities: {}, protocolVersion: 1 },
+      120_000,
+    );
+  });
+
   it("extracts model-category options", () => {
     expect(getAmpModelOptions(session)).toEqual([
       { value: "smart", name: "Smart" },
@@ -136,6 +150,37 @@ describe("Amp ACP configuration", () => {
         { sessionId: "session-1", configId: "permission", value: "default" },
       ],
     ]);
+  });
+
+  it("uses the caller timeout for every configuration request", async () => {
+    const request = vi.fn().mockResolvedValue({});
+
+    await applyAmpSessionOptions(
+      { request },
+      session,
+      {
+        model: "deep",
+        codexPermissionMode: "full-access",
+        reasoningEffort: "max",
+      },
+      120_000,
+    );
+
+    expect(request).toHaveBeenCalledTimes(3);
+    for (const call of request.mock.calls) {
+      expect(call[2]).toBe(120_000);
+    }
+  });
+
+  it("reports a missing model selection separately", async () => {
+    const request = vi.fn().mockResolvedValue({});
+
+    await expect(
+      applyAmpSessionOptions({ request }, session, {
+        codexPermissionMode: "default",
+      }),
+    ).rejects.toThrow("requires a model selection");
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported models and missing full-access bypass", async () => {

--- a/electron/api/providers/amp-acp.test.js
+++ b/electron/api/providers/amp-acp.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyAmpSessionOptions,
+  getAmpModelOptions,
+  getAmpReasoningEfforts,
+  initializeAmpAcp,
+  isAmpAcpVersionSupported,
+} from "./amp-acp.js";
+
+const session = {
+  sessionId: "session-1",
+  configOptions: [
+    {
+      category: "model",
+      id: "amp-mode",
+      options: [
+        { value: "smart", name: "Smart" },
+        { value: "deep", name: "Deep" },
+      ],
+    },
+    {
+      category: "mode",
+      id: "permission",
+      options: [{ value: "default" }, { value: "bypass" }],
+    },
+    {
+      category: "thought_level",
+      id: "effort",
+      options: [{ value: "high" }, { value: "max" }],
+    },
+  ],
+};
+
+describe("Amp ACP configuration", () => {
+  it("requires an adapter compatible with current Amp CLI releases", () => {
+    expect(isAmpAcpVersionSupported("0.8.1")).toBe(false);
+    expect(isAmpAcpVersionSupported("0.8.99")).toBe(false);
+    expect(isAmpAcpVersionSupported("0.9.0")).toBe(true);
+    expect(isAmpAcpVersionSupported("0.9.1")).toBe(true);
+    expect(isAmpAcpVersionSupported("1.0.0")).toBe(true);
+    expect(isAmpAcpVersionSupported(null)).toBe(false);
+    expect(isAmpAcpVersionSupported("v0.9.0")).toBe(false);
+    expect(isAmpAcpVersionSupported("0.9.0-beta.1")).toBe(false);
+  });
+
+  it("validates the adapter identity and version during initialization", async () => {
+    const request = vi.fn().mockResolvedValue({
+      agentInfo: { name: "amp-acp", version: "0.9.0" },
+    });
+    await expect(initializeAmpAcp({ request })).resolves.toMatchObject({
+      agentInfo: { name: "amp-acp", version: "0.9.0" },
+    });
+
+    request.mockResolvedValueOnce({
+      agentInfo: { name: "amp-acp", version: "0.8.99" },
+    });
+    await expect(initializeAmpAcp({ request })).rejects.toThrow(
+      "Install amp-acp 0.9.0 or newer",
+    );
+
+    request.mockResolvedValueOnce({
+      agentInfo: { name: "acp-amp", version: "1.0.0" },
+    });
+    await expect(initializeAmpAcp({ request })).rejects.toThrow(
+      "expected amp-acp",
+    );
+  });
+
+  it("extracts model-category options", () => {
+    expect(getAmpModelOptions(session)).toEqual([
+      { value: "smart", name: "Smart" },
+      { value: "deep", name: "Deep" },
+    ]);
+  });
+
+  it("extracts the currently advertised effort options", () => {
+    expect(getAmpReasoningEfforts(session)).toEqual(["high", "max"]);
+    expect(
+      getAmpReasoningEfforts({
+        ...session,
+        configOptions: session.configOptions.filter(
+          (option) => option.id !== "effort",
+        ),
+      }),
+    ).toEqual([]);
+  });
+
+  it("applies supported mode, full-access permission, and effort", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    await applyAmpSessionOptions({ request }, session, {
+      model: "deep",
+      codexPermissionMode: "full-access",
+      reasoningEffort: "max",
+    });
+    expect(request.mock.calls).toEqual([
+      [
+        "session/set_config_option",
+        { sessionId: "session-1", configId: "amp-mode", value: "deep" },
+      ],
+      [
+        "session/set_config_option",
+        { sessionId: "session-1", configId: "permission", value: "bypass" },
+      ],
+      [
+        "session/set_config_option",
+        { sessionId: "session-1", configId: "effort", value: "max" },
+      ],
+    ]);
+  });
+
+  it("does not send an effort unsupported after changing mode", async () => {
+    const request = vi.fn().mockImplementation(async (_method, params) => {
+      if (params.configId !== "amp-mode") return {};
+      return {
+        configOptions: session.configOptions.map((option) =>
+          option.id === "effort"
+            ? { ...option, options: [{ value: "low" }] }
+            : option,
+        ),
+      };
+    });
+
+    await applyAmpSessionOptions({ request }, session, {
+      model: "deep",
+      codexPermissionMode: "default",
+      reasoningEffort: "max",
+    });
+
+    expect(request.mock.calls).toEqual([
+      [
+        "session/set_config_option",
+        { sessionId: "session-1", configId: "amp-mode", value: "deep" },
+      ],
+      [
+        "session/set_config_option",
+        { sessionId: "session-1", configId: "permission", value: "default" },
+      ],
+    ]);
+  });
+
+  it("rejects unsupported models and missing full-access bypass", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    await expect(
+      applyAmpSessionOptions({ request }, session, {
+        model: "unknown",
+        codexPermissionMode: "default",
+      }),
+    ).rejects.toThrow('requested model "unknown"');
+    expect(request).not.toHaveBeenCalled();
+
+    await expect(
+      applyAmpSessionOptions(
+        { request },
+        {
+          ...session,
+          configOptions: session.configOptions.map((option) =>
+            option.id === "permission"
+              ? { ...option, options: [{ value: "default" }] }
+              : option,
+          ),
+        },
+        { model: "deep", codexPermissionMode: "full-access" },
+      ),
+    ).rejects.toThrow('requested permission mode "bypass"');
+  });
+});

--- a/electron/api/providers/grok-acp.js
+++ b/electron/api/providers/grok-acp.js
@@ -1,9 +1,6 @@
 import { spawn } from "node:child_process";
-import readline from "node:readline";
 import { resolveCliCommandPath } from "../shared/cli.js";
-
-const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
-const MAX_STDERR_CHARS = 64_000;
+import { AcpConnection, initializeAcp } from "./acp-transport.js";
 
 const getGrokPermissionMode = ({ agentMode, codexPermissionMode }) => {
   if (codexPermissionMode === "full-access") return "bypassPermissions";
@@ -32,138 +29,6 @@ const createGrokArgs = ({
   return args;
 };
 
-export class GrokAcpConnection {
-  constructor(child) {
-    this.child = child;
-    this.closed = false;
-    this.nextId = 1;
-    this.pending = new Map();
-    this.stderr = "";
-    this.onNotification = null;
-    this.onRequest = null;
-    this.reader = readline.createInterface({ input: child.stdout });
-
-    this.reader.on("line", (line) => this.handleLine(line));
-    child.stderr.on("data", (chunk) => {
-      this.stderr = `${this.stderr}${chunk.toString()}`.slice(
-        -MAX_STDERR_CHARS,
-      );
-    });
-    child.on("error", (error) => this.failPending(error));
-    child.on("close", (code) => {
-      this.closed = true;
-      this.reader.close();
-      const detail = this.stderr.trim();
-      this.failPending(
-        new Error(
-          detail ||
-            (code === 0
-              ? "Grok ACP connection closed."
-              : `Grok CLI exited with code ${code}.`),
-        ),
-      );
-    });
-  }
-
-  handleLine(line) {
-    let message;
-    try {
-      message = JSON.parse(line);
-    } catch {
-      return;
-    }
-
-    if (message.id !== undefined && !message.method) {
-      const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      clearTimeout(pending.timer);
-      if (message.error) {
-        pending.reject(
-          new Error(
-            message.error.message ||
-              message.error.data?.message ||
-              JSON.stringify(message.error),
-          ),
-        );
-      } else {
-        pending.resolve(message.result ?? {});
-      }
-      return;
-    }
-
-    if (message.method && message.id !== undefined) {
-      void this.handleIncomingRequest(message);
-      return;
-    }
-
-    if (message.method) {
-      this.onNotification?.(message.method, message.params ?? {});
-    }
-  }
-
-  async handleIncomingRequest(message) {
-    try {
-      if (!this.onRequest) {
-        throw new Error(`Unsupported Grok ACP request: ${message.method}`);
-      }
-      const result = await this.onRequest(message.method, message.params ?? {});
-      this.write({ jsonrpc: "2.0", id: message.id, result: result ?? {} });
-    } catch (error) {
-      this.write({
-        jsonrpc: "2.0",
-        id: message.id,
-        error: {
-          code: -32603,
-          message:
-            error instanceof Error ? error.message : "Grok ACP request failed.",
-        },
-      });
-    }
-  }
-
-  write(message) {
-    if (this.closed || !this.child.stdin.writable) return;
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
-  }
-
-  request(method, params, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
-    if (this.closed) {
-      return Promise.reject(new Error("Grok ACP connection is closed."));
-    }
-
-    const id = this.nextId++;
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Grok ACP ${method} request timed out.`));
-      }, timeoutMs);
-      this.pending.set(id, { reject, resolve, timer });
-      this.write({ jsonrpc: "2.0", id, method, params });
-    });
-  }
-
-  notify(method, params) {
-    this.write({ jsonrpc: "2.0", method, params });
-  }
-
-  failPending(error) {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(error);
-    }
-    this.pending.clear();
-  }
-
-  close() {
-    if (this.closed) return;
-    this.closed = true;
-    this.reader.close();
-    this.failPending(new Error("Grok ACP connection closed."));
-    this.child.kill();
-  }
-}
-
 export const spawnGrokAcp = async (options = {}) => {
   const command = await resolveCliCommandPath("grok");
   if (!command) {
@@ -183,14 +48,10 @@ export const spawnGrokAcp = async (options = {}) => {
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   });
-  return new GrokAcpConnection(child);
+  return new AcpConnection(child, "Grok", "Grok CLI");
 };
 
-export const initializeGrokAcp = (connection) =>
-  connection.request("initialize", {
-    protocolVersion: 1,
-    clientCapabilities: {},
-  });
+export const initializeGrokAcp = initializeAcp;
 
 export const authenticateGrokAcp = async (connection, initializeResult) => {
   const methods = Array.isArray(initializeResult?.authMethods)

--- a/electron/api/providers/model-options.js
+++ b/electron/api/providers/model-options.js
@@ -190,6 +190,11 @@ const formatModelIdLabel = (provider, modelId) => {
   if (!trimmed) return "";
   const parts = trimmed.split("-").filter(Boolean);
   if (parts.length === 0) return trimmed;
+  if (provider === "amp") {
+    return parts
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
   if (provider === "openai" && parts[0]?.toLowerCase() === "gpt") {
     const [, version, ...rest] = parts;
     if (!version) return "GPT";

--- a/electron/api/providers/model-options.test.js
+++ b/electron/api/providers/model-options.test.js
@@ -58,6 +58,11 @@ test("limits Grok reasoning efforts to grok models without composer", () => {
   assert.deepEqual(getModelReasoningEfforts("cursor", "grok-4"), []);
 });
 
+test("formats Amp modes as readable model labels", () => {
+  assert.equal(createModelOption("amp", "smart", "Smart").label, "Smart");
+  assert.equal(createModelOption("amp", "high", "high").label, "High");
+});
+
 test("offers speed tiers only for OpenAI gpt-5.4 and gpt-5.5 families", () => {
   assert.deepEqual(getModelSpeedTiers("openai", "gpt-5.4"), [
     "standard",

--- a/electron/api/providers/provider-models.js
+++ b/electron/api/providers/provider-models.js
@@ -3,6 +3,13 @@ import {
   getCliVersion,
   isCliCommandAvailable,
 } from "../shared/cli.js";
+import {
+  getAmpConfigOptions,
+  getAmpModelOptions,
+  getAmpReasoningEfforts,
+  initializeAmpAcp,
+  spawnAmpAcp,
+} from "./amp-acp.js";
 import { readCodexAccessToken, readCodexModelsCache } from "./codex-auth.js";
 import {
   execCursorCliCommand,
@@ -404,6 +411,89 @@ export const fetchGrokModels = async ({ force = false } = {}) => {
       models: [],
       source: "unavailable",
       version,
+    };
+  } finally {
+    connection?.close();
+  }
+};
+
+export const fetchAmpModels = async () => {
+  const installed = await isCliCommandAvailable("amp-acp");
+  if (!installed) {
+    return {
+      error:
+        "Amp ACP adapter is not installed or available on PATH. Install amp-acp, then run `amp login` or complete adapter setup.",
+      installed: false,
+      models: [],
+      source: "unavailable",
+      version: null,
+    };
+  }
+
+  let connection;
+  try {
+    connection = await spawnAmpAcp();
+    const initializeResult = await initializeAmpAcp(connection);
+    const version = initializeResult.agentInfo.version;
+    const session = await connection.request("session/new", {
+      cwd: process.cwd(),
+      mcpServers: [],
+    });
+    const modelEntries = getAmpModelOptions(session);
+    const models = [];
+    let currentSession = session;
+    for (const entry of modelEntries) {
+      const id = String(
+        typeof entry === "string" ? entry : (entry?.value ?? entry?.id ?? ""),
+      ).trim();
+      if (!id) continue;
+
+      const currentModel = getAmpConfigOptions(currentSession).find(
+        (option) => option?.id === "amp-mode",
+      )?.currentValue;
+      if (currentModel !== id) {
+        const result = await connection.request("session/set_config_option", {
+          sessionId: session.sessionId,
+          configId: "amp-mode",
+          value: id,
+        });
+        if (Array.isArray(result?.configOptions)) {
+          currentSession = { ...session, configOptions: result.configOptions };
+        }
+      }
+
+      const fallbackLabel = id.charAt(0).toUpperCase() + id.slice(1);
+      const label = entry?.name ?? entry?.label ?? fallbackLabel;
+      models.push(
+        createModelOption(
+          "amp",
+          id,
+          `Amp ${label}`,
+          normalizeReasoningEfforts(getAmpReasoningEfforts(currentSession)),
+        ),
+      );
+    }
+    if (!models.length) {
+      throw new Error(
+        "Amp ACP returned no mode options. Complete adapter setup and try again.",
+      );
+    }
+    return {
+      installed: true,
+      models: dedupeModelOptions(models),
+      source: "cli",
+      version,
+    };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? `Unable to query Amp ACP: ${error.message}`
+          : "Unable to query Amp ACP. Run `amp login` or complete adapter setup.",
+      installed: true,
+      models: [],
+      source: "unavailable",
+      version: error?.ampAcpVersion ?? null,
     };
   } finally {
     connection?.close();

--- a/electron/api/providers/provider-models.js
+++ b/electron/api/providers/provider-models.js
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import {
   execCliCommand,
   getCliVersion,
@@ -39,6 +40,8 @@ const OPENAI_CODEX_CHATGPT_MODELS_URL =
   "https://chatgpt.com/backend-api/codex/models";
 const CODEX_CLIENT_VERSION = "1.0.0";
 const CURSOR_AUTO_MODEL = "auto";
+const ampModelsByVersion = new Map();
+let lastAmpAdapterVersion = null;
 
 const dedupeAndSort = (models) => {
   return dedupeModelOptions(models)
@@ -417,7 +420,7 @@ export const fetchGrokModels = async ({ force = false } = {}) => {
   }
 };
 
-export const fetchAmpModels = async () => {
+export const fetchAmpModels = async ({ force = false } = {}) => {
   const installed = await isCliCommandAvailable("amp-acp");
   if (!installed) {
     return {
@@ -429,6 +432,15 @@ export const fetchAmpModels = async () => {
       version: null,
     };
   }
+  // amp-acp is a stdio server without a --version command; initialize provides
+  // the adapter version used as the cache key below.
+  if (
+    !force &&
+    lastAmpAdapterVersion &&
+    ampModelsByVersion.has(lastAmpAdapterVersion)
+  ) {
+    return ampModelsByVersion.get(lastAmpAdapterVersion);
+  }
 
   let connection;
   try {
@@ -436,7 +448,7 @@ export const fetchAmpModels = async () => {
     const initializeResult = await initializeAmpAcp(connection);
     const version = initializeResult.agentInfo.version;
     const session = await connection.request("session/new", {
-      cwd: process.cwd(),
+      cwd: tmpdir(),
       mcpServers: [],
     });
     const modelEntries = getAmpModelOptions(session);
@@ -478,12 +490,15 @@ export const fetchAmpModels = async () => {
         "Amp ACP returned no mode options. Complete adapter setup and try again.",
       );
     }
-    return {
+    const result = {
       installed: true,
       models: dedupeModelOptions(models),
       source: "cli",
       version,
     };
+    ampModelsByVersion.set(version, result);
+    lastAmpAdapterVersion = version;
+    return result;
   } catch (error) {
     return {
       error:

--- a/electron/persisted-state.js
+++ b/electron/persisted-state.js
@@ -19,6 +19,7 @@ const DEFAULT_PERSISTED_STATE = {
   messagesByChatId: {},
   projects: [],
   settings: {
+    ampSelectedModels: [],
     anthropicSelectedModels: [],
     archiveChatsAfterDays: 30,
     cursorSelectedModels: [],
@@ -51,6 +52,7 @@ const PERSISTED_STATE_CONFIG_KEYS = [
   "settings.defaultGitGenerationModel",
   "settings.defaultModelSpeed",
   "settings.defaultReasoningEffort",
+  "settings.ampSelectedModels",
   "settings.openAiSelectedModels",
   "settings.anthropicSelectedModels",
   "settings.openCodeSelectedModels",
@@ -665,6 +667,14 @@ function saveStateToRelationalDatabase(database, state) {
     );
     writeConfig(
       database,
+      "settings.ampSelectedModels",
+      Array.isArray(settings.ampSelectedModels)
+        ? settings.ampSelectedModels
+        : [],
+      now,
+    );
+    writeConfig(
+      database,
       "settings.openAiSelectedModels",
       Array.isArray(settings.openAiSelectedModels)
         ? settings.openAiSelectedModels
@@ -1138,6 +1148,9 @@ function loadStateFromRelationalDatabase(database) {
     messagesByChatId,
     projects,
     settings: {
+      ampSelectedModels: Array.isArray(config["settings.ampSelectedModels"])
+        ? config["settings.ampSelectedModels"]
+        : [],
       anthropicSelectedModels: Array.isArray(
         config["settings.anthropicSelectedModels"],
       )

--- a/src/components/ai-elements/provider-icons.tsx
+++ b/src/components/ai-elements/provider-icons.tsx
@@ -90,6 +90,22 @@ export const GrokIcon = ({
   </svg>
 );
 
+export const AmpIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    className={cn("size-3.5", className)}
+    fill="none"
+    role="img"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M4 19 10.5 5h3L20 19h-3.4l-1.3-3H8.7l-1.3 3H4Zm5.9-5.8h4.2L12 8.3l-2.1 4.9Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const ProviderIcon = ({
   provider,
   ...props
@@ -98,5 +114,6 @@ export const ProviderIcon = ({
   if (provider === "opencode") return <OpenCodeIcon {...props} />;
   if (provider === "cursor") return <CursorIcon {...props} />;
   if (provider === "grok") return <GrokIcon {...props} />;
+  if (provider === "amp") return <AmpIcon {...props} />;
   return <OpenAiIcon {...props} />;
 };

--- a/src/components/ide/assistant-message-tools.test.ts
+++ b/src/components/ide/assistant-message-tools.test.ts
@@ -55,6 +55,36 @@ test("getChipToolKind classifies known tool aliases", () => {
   );
 });
 
+test("getChipToolKind recovers ACP tool names from older generic command parts", () => {
+  assert.equal(
+    getChipToolKind(
+      createToolPart("dynamic-tool", {
+        title: "shell_command: pwd",
+        toolName: "command",
+      }),
+    ),
+    "command",
+  );
+  assert.equal(
+    getChipToolKind(
+      createToolPart("dynamic-tool", {
+        title: "apply_patch: Update files",
+        toolName: "command",
+      }),
+    ),
+    "write",
+  );
+  assert.equal(
+    getChipToolKind(
+      createToolPart("dynamic-tool", {
+        title: "web_search: Search documentation",
+        toolName: "command",
+      }),
+    ),
+    "webFetch",
+  );
+});
+
 test("getChipToolKind recognizes mcp tools via dynamic-tool names", () => {
   assert.equal(
     getChipToolKind(

--- a/src/components/ide/assistant-message-tools.ts
+++ b/src/components/ide/assistant-message-tools.ts
@@ -22,6 +22,14 @@ export const isToolLikePart = (part: MessagePart): part is ToolLikePart =>
 
 export const getToolName = (part: ToolLikePart): string => {
   if (part.type === "dynamic-tool" && isString(part.toolName)) {
+    if (
+      normalizeToolName(part.toolName) === "command" &&
+      "title" in part &&
+      isString(part.title)
+    ) {
+      const acpToolName = part.title.split(":", 1)[0].trim();
+      if (acpToolName) return acpToolName;
+    }
     return part.toolName;
   }
 

--- a/src/components/ide/assistant-message/chips/run-command-chip.tsx
+++ b/src/components/ide/assistant-message/chips/run-command-chip.tsx
@@ -57,21 +57,27 @@ export const RunCommandChip = ({
         ? output.type
         : null;
   const commandOutput = useMemo(() => {
-    if (isString(output)) {
-      return stripAnsiSequences(output);
+    let normalizedOutput = output;
+    if (isString(normalizedOutput)) {
+      const serializedOutput = normalizedOutput;
+      try {
+        normalizedOutput = JSON.parse(serializedOutput);
+      } catch {
+        return stripAnsiSequences(serializedOutput);
+      }
     }
 
-    if (!isRecord(output)) {
+    if (!isRecord(normalizedOutput)) {
       return null;
     }
 
-    const combinedOutput = [output.stdout, output.stderr]
+    const combinedOutput = [normalizedOutput.stdout, normalizedOutput.stderr]
       .filter(isString)
-      .join(output.stdout && output.stderr ? "\n" : "");
+      .join(normalizedOutput.stdout && normalizedOutput.stderr ? "\n" : "");
     const textOutput =
-      (isString(output.output) && output.output) ||
+      (isString(normalizedOutput.output) && normalizedOutput.output) ||
       combinedOutput ||
-      (isString(output.result) ? output.result : null);
+      (isString(normalizedOutput.result) ? normalizedOutput.result : null);
 
     return textOutput ? stripAnsiSequences(textOutput) : null;
   }, [output]);

--- a/src/components/ide/chat-panel.tsx
+++ b/src/components/ide/chat-panel.tsx
@@ -812,14 +812,7 @@ export const ChatPanel = ({
     [messages],
   );
 
-  const modelId =
-    selectedProvider === "anthropic"
-      ? `anthropic:${selectedModel}`
-      : selectedProvider === "opencode"
-        ? `opencode:${selectedModel}`
-        : selectedProvider === "cursor"
-          ? `cursor:${selectedModel}`
-          : `openai:${selectedModel}`;
+  const modelId = `${selectedProvider}:${selectedModel}`;
 
   const isStreaming = status === "streaming";
   const isProcessing = status === "submitted" || status === "streaming";
@@ -1226,6 +1219,8 @@ export const ChatPanel = ({
           onModelChange={(nextOption) => {
             updateChat(chat.id, (current) => ({
               ...current,
+              agentMode:
+                nextOption.provider === "amp" ? "build" : current.agentMode,
               model: nextOption.id,
               modelSpeed: "standard",
               provider: nextOption.provider,

--- a/src/components/ide/chat/chat-composer.tsx
+++ b/src/components/ide/chat/chat-composer.tsx
@@ -1020,7 +1020,11 @@ export const ChatComposer = ({
                       <SelectItem className="text-xs" value="standard">
                         <span className="flex items-center gap-1.5">
                           <Shield className="size-3.5 shrink-0 text-surface-500 dark:text-surface-400" />
-                          <span>{chatT("standardPermissions")}</span>
+                          <span>
+                            {selectedProvider === "amp"
+                              ? chatT("ampManagedPermissions")
+                              : chatT("standardPermissions")}
+                          </span>
                         </span>
                       </SelectItem>
                       <SelectItem className="text-xs" value="full-access">
@@ -1052,7 +1056,11 @@ export const ChatComposer = ({
                   <SelectContent className="text-xs" side="top">
                     <SelectGroup>
                       <SelectLabel>{chatT("mode")}</SelectLabel>
-                      {AGENT_MODE_OPTIONS.map((option) => {
+                      {AGENT_MODE_OPTIONS.filter(
+                        (option) =>
+                          selectedProvider !== "amp" ||
+                          option.value === "build",
+                      ).map((option) => {
                         const OptionIcon = getAgentModeIcon(option.value);
 
                         return (

--- a/src/components/ide/chat/chat-message.tsx
+++ b/src/components/ide/chat/chat-message.tsx
@@ -41,6 +41,7 @@ export const PROVIDER_LABELS: Record<AiProvider, string> = {
   opencode: "OpenCode",
   cursor: "Cursor",
   grok: "Grok Build",
+  amp: "Amp",
 };
 
 export const CHAT_STREAM_UPDATE_THROTTLE_MS = 50;

--- a/src/components/ide/ide-shell.tsx
+++ b/src/components/ide/ide-shell.tsx
@@ -309,9 +309,11 @@ export const IdeShell = () => {
     const openCodeSelectedModels = dedupeModels(prev.openCodeSelectedModels);
     const cursorSelectedModels = dedupeModels(prev.cursorSelectedModels);
     const grokSelectedModels = dedupeModels(prev.grokSelectedModels);
+    const ampSelectedModels = dedupeModels(prev.ampSelectedModels);
     const nextSettings = {
       ...prev,
       anthropicSelectedModels,
+      ampSelectedModels,
       cursorSelectedModels,
       grokSelectedModels,
       openCodeSelectedModels,
@@ -333,6 +335,7 @@ export const IdeShell = () => {
       openCodeSelectedModels.length !== prev.openCodeSelectedModels.length ||
       cursorSelectedModels.length !== prev.cursorSelectedModels.length ||
       grokSelectedModels.length !== prev.grokSelectedModels.length ||
+      ampSelectedModels.length !== prev.ampSelectedModels.length ||
       !openAiSelectedModels.every(
         (m, i) => prev.openAiSelectedModels[i] === m,
       ) ||
@@ -345,7 +348,8 @@ export const IdeShell = () => {
       !cursorSelectedModels.every(
         (m, i) => prev.cursorSelectedModels[i] === m,
       ) ||
-      !grokSelectedModels.every((m, i) => prev.grokSelectedModels[i] === m);
+      !grokSelectedModels.every((m, i) => prev.grokSelectedModels[i] === m) ||
+      !ampSelectedModels.every((m, i) => prev.ampSelectedModels[i] === m);
 
     if (changed) {
       store.setSettings(normalizedDefaultSettings);

--- a/src/components/ide/ide-state.ts
+++ b/src/components/ide/ide-state.ts
@@ -282,7 +282,8 @@ const normalizeProvider = (value: unknown): AiProvider => {
   return value === "anthropic" ||
     value === "opencode" ||
     value === "cursor" ||
-    value === "grok"
+    value === "grok" ||
+    value === "amp"
     ? value
     : DEFAULT_PROVIDER;
 };
@@ -688,6 +689,11 @@ export const mergePersistedState = (
     grokSelectedModels: dedupeModels(
       Array.isArray(rawSettings.grokSelectedModels)
         ? rawSettings.grokSelectedModels
+        : [],
+    ),
+    ampSelectedModels: dedupeModels(
+      Array.isArray(rawSettings.ampSelectedModels)
+        ? rawSettings.ampSelectedModels
         : [],
     ),
     openAiSelectedModels: dedupeModels(

--- a/src/components/ide/ide-types.ts
+++ b/src/components/ide/ide-types.ts
@@ -37,6 +37,7 @@ export interface ProviderModelsResponse {
   opencode?: ProviderModelFetchResult;
   cursor?: ProviderModelFetchResult;
   grok?: ProviderModelFetchResult;
+  amp?: ProviderModelFetchResult;
 }
 
 export interface ProviderModelState {
@@ -96,6 +97,7 @@ export const ALL_PROVIDERS: AiProvider[] = [
   "opencode",
   "cursor",
   "grok",
+  "amp",
 ];
 
 export const getProviderLabel = (provider: AiProvider): string => {
@@ -103,6 +105,7 @@ export const getProviderLabel = (provider: AiProvider): string => {
   if (provider === "opencode") return "OpenCode";
   if (provider === "cursor") return "Cursor";
   if (provider === "grok") return "Grok Build";
+  if (provider === "amp") return "Amp";
   return "Anthropic";
 };
 
@@ -119,6 +122,7 @@ export const getProviderDescription = (provider: AiProvider): string => {
   if (provider === "grok") {
     return "Uses the local Grok Build CLI through ACP.";
   }
+  if (provider === "amp") return "Uses the local Amp ACP adapter.";
   return "Uses the local Claude Code CLI for Claude models.";
 };
 
@@ -144,6 +148,8 @@ export const getEnabledProviders = (settings: AppSettings): AiProvider[] => {
   if (settings.grokSelectedModels.length > 0) {
     providers.push("grok");
   }
+
+  if (settings.ampSelectedModels.length > 0) providers.push("amp");
 
   return providers;
 };

--- a/src/components/ide/settings-dialog.tsx
+++ b/src/components/ide/settings-dialog.tsx
@@ -1,5 +1,6 @@
 import {
   Archive,
+  ExternalLink,
   Monitor,
   Moon,
   Plug,
@@ -14,7 +15,12 @@ import { useEffect, useMemo, useState } from "react";
 import anthropicLogo from "@/assets/anthropic.svg";
 import openAiLogo from "@/assets/openai.svg";
 import openCodeLogo from "@/assets/opencode.svg";
-import { CursorIcon, GrokIcon } from "@/components/ai-elements/provider-icons";
+import { CodeBlockCopyButton } from "@/components/ai-elements/code-block";
+import {
+  AmpIcon,
+  CursorIcon,
+  GrokIcon,
+} from "@/components/ai-elements/provider-icons";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -159,6 +165,7 @@ export const SettingsDialog = () => {
   const archiveInactiveChats = useIdeStore((s) => s.archiveInactiveChats);
   const permanentlyDeleteChats = useIdeStore((s) => s.permanentlyDeleteChats);
   const restoreChats = useIdeStore((s) => s.restoreChats);
+  const openExternalUrl = useIdeStore((s) => s.openExternalUrl);
 
   const accentColor = useUiStore((s) => s.accentColor);
   const baseColor = useUiStore((s) => s.baseColor);
@@ -248,11 +255,16 @@ export const SettingsDialog = () => {
     () => getModelsForProvider("grok", settings),
     [settings],
   );
+  const ampModels = useMemo(
+    () => getModelsForProvider("amp", settings),
+    [settings],
+  );
   const availableOpenAiModels = providerModels.openai.models;
   const availableAnthropicModels = providerModels.anthropic.models;
   const availableOpenCodeModels = providerModels.opencode.models;
   const availableCursorModels = providerModels.cursor.models;
   const availableGrokModels = providerModels.grok.models;
+  const availableAmpModels = providerModels.amp.models;
 
   const openAiModelOptions = useMemo(
     () => getModelOptionsForProvider("openai", settings, availableOpenAiModels),
@@ -280,6 +292,10 @@ export const SettingsDialog = () => {
     () => getModelOptionsForProvider("grok", settings, availableGrokModels),
     [availableGrokModels, settings],
   );
+  const ampModelOptions = useMemo(
+    () => getModelOptionsForProvider("amp", settings, availableAmpModels),
+    [availableAmpModels, settings],
+  );
   const groupedDefaultModelOptions = useMemo(
     () =>
       [
@@ -288,9 +304,11 @@ export const SettingsDialog = () => {
         { models: openCodeModelOptions, provider: "opencode" as const },
         { models: cursorModelOptions, provider: "cursor" as const },
         { models: grokModelOptions, provider: "grok" as const },
+        { models: ampModelOptions, provider: "amp" as const },
       ].filter((group) => group.models.length > 0),
     [
       anthropicModelOptions,
+      ampModelOptions,
       cursorModelOptions,
       grokModelOptions,
       openAiModelOptions,
@@ -479,8 +497,20 @@ export const SettingsDialog = () => {
   const handleRefreshGrokProvider = () => {
     void refreshProviderModels({ force: true, provider: "grok" });
   };
+  const handleRefreshAmpProvider = () => {
+    void refreshProviderModels({ force: true, provider: "amp" });
+  };
   const getProviderError = (error: string | null) =>
     error ? uiT("unableToFetchModels") : null;
+  const ampVersion = providerModels.amp.version?.match(/^(\d+)\.(\d+)\.(\d+)/);
+  const ampAdapterOutdated = ampVersion
+    ? Number(ampVersion[1]) === 0 && Number(ampVersion[2]) < 9
+    : false;
+  const ampProviderError = ampAdapterOutdated
+    ? settingsT("ampAdapterUpdateRequired", {
+        version: providerModels.amp.version ?? "0.8",
+      })
+    : getProviderError(providerModels.amp.error);
 
   return (
     <Dialog onOpenChange={setSettingsOpen} open={settingsOpen}>
@@ -962,6 +992,118 @@ export const SettingsDialog = () => {
                   ) : null}
 
                   <div className="grid gap-3">
+                    <ProviderStatusCard
+                      action={
+                        <Button
+                          aria-label={settingsT("refreshProvider", {
+                            provider: "Amp",
+                          })}
+                          disabled={providerModels.amp.loading}
+                          onClick={handleRefreshAmpProvider}
+                          size="icon-xs"
+                          title={settingsT("refreshProvider", {
+                            provider: "Amp",
+                          })}
+                          type="button"
+                          variant="ghost"
+                        >
+                          <RotateCw className="size-3.5" />
+                        </Button>
+                      }
+                      error={ampProviderError}
+                      help={
+                        <div className="space-y-2 rounded-md border border-surface-200 bg-surface-50 px-3 py-2.5 text-sm dark:border-surface-800 dark:bg-surface-900">
+                          <p className="text-muted-foreground">
+                            {settingsT("ampAdapterHelp")}
+                          </p>
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <p className="text-muted-foreground text-xs">
+                                {settingsT("ampAdapterInstall")}
+                              </p>
+                              <div className="flex items-center gap-1">
+                                <code className="select-all font-mono text-xs">
+                                  npm install -g amp-acp@latest
+                                </code>
+                                <CodeBlockCopyButton
+                                  aria-label={settingsT("ampAdapterInstall")}
+                                  text="npm install -g amp-acp@latest"
+                                  title={settingsT("ampAdapterInstall")}
+                                />
+                              </div>
+                            </div>
+                            <Button
+                              onClick={() =>
+                                openExternalUrl(
+                                  "https://github.com/tao12345666333/amp-acp",
+                                )
+                              }
+                              size="sm"
+                              type="button"
+                              variant="outline"
+                            >
+                              {settingsT("ampAdapterDocs")}
+                              <ExternalLink className="size-3.5" />
+                            </Button>
+                          </div>
+                          <p className="text-muted-foreground text-xs">
+                            {settingsT("ampAdapterPrerequisite")}
+                          </p>
+                        </div>
+                      }
+                      icon={
+                        <AmpIcon
+                          aria-hidden="true"
+                          className="size-4 text-foreground"
+                        />
+                      }
+                      installed={providerModels.amp.installed}
+                      label="Amp"
+                      loading={providerModels.amp.loading}
+                      runtimeLabel="amp-acp"
+                      version={providerModels.amp.version}
+                    >
+                      <div className="space-y-1.5 rounded-md p-1">
+                        {availableAmpModels.length === 0 ? (
+                          <p className="px-2 py-1.5 text-muted-foreground text-sm">
+                            {settingsT("noCliModels")}
+                          </p>
+                        ) : (
+                          availableAmpModels.map((model) => {
+                            const isSelected = ampModels.includes(model.id);
+                            return (
+                              <div
+                                className="flex items-center justify-between rounded-sm px-1.5 py-1 hover:bg-muted"
+                                key={model.id}
+                              >
+                                <Label
+                                  className={cn(
+                                    "truncate pr-3 text-sm",
+                                    isSelected
+                                      ? "text-foreground"
+                                      : "text-muted-foreground",
+                                  )}
+                                >
+                                  {model.label}
+                                </Label>
+                                <Switch
+                                  checked={isSelected}
+                                  onCheckedChange={(checked) => {
+                                    if (checked !== isSelected) {
+                                      toggleProviderModel(
+                                        "amp",
+                                        model.id,
+                                        checked,
+                                      );
+                                    }
+                                  }}
+                                />
+                              </div>
+                            );
+                          })
+                        )}
+                      </div>
+                    </ProviderStatusCard>
                     <ProviderStatusCard
                       action={
                         <Button

--- a/src/components/ide/settings-dialog.tsx
+++ b/src/components/ide/settings-dialog.tsx
@@ -265,6 +265,11 @@ export const SettingsDialog = () => {
   const availableCursorModels = providerModels.cursor.models;
   const availableGrokModels = providerModels.grok.models;
   const availableAmpModels = providerModels.amp.models;
+  const ampVersion = providerModels.amp.version?.match(/^(\d+)\.(\d+)\.(\d+)/);
+  const ampAdapterOutdated = ampVersion
+    ? Number(ampVersion[1]) === 0 && Number(ampVersion[2]) < 9
+    : false;
+  const ampProviderUsable = providerModels.amp.installed && !ampAdapterOutdated;
 
   const openAiModelOptions = useMemo(
     () => getModelOptionsForProvider("openai", settings, availableOpenAiModels),
@@ -293,8 +298,11 @@ export const SettingsDialog = () => {
     [availableGrokModels, settings],
   );
   const ampModelOptions = useMemo(
-    () => getModelOptionsForProvider("amp", settings, availableAmpModels),
-    [availableAmpModels, settings],
+    () =>
+      ampProviderUsable
+        ? getModelOptionsForProvider("amp", settings, availableAmpModels)
+        : [],
+    [ampProviderUsable, availableAmpModels, settings],
   );
   const groupedDefaultModelOptions = useMemo(
     () =>
@@ -502,10 +510,6 @@ export const SettingsDialog = () => {
   };
   const getProviderError = (error: string | null) =>
     error ? uiT("unableToFetchModels") : null;
-  const ampVersion = providerModels.amp.version?.match(/^(\d+)\.(\d+)\.(\d+)/);
-  const ampAdapterOutdated = ampVersion
-    ? Number(ampVersion[1]) === 0 && Number(ampVersion[2]) < 9
-    : false;
   const ampProviderError = ampAdapterOutdated
     ? settingsT("ampAdapterUpdateRequired", {
         version: providerModels.amp.version ?? "0.8",
@@ -1026,9 +1030,9 @@ export const SettingsDialog = () => {
                                   npm install -g amp-acp@latest
                                 </code>
                                 <CodeBlockCopyButton
-                                  aria-label={settingsT("ampAdapterInstall")}
+                                  aria-label={settingsT("copy")}
                                   text="npm install -g amp-acp@latest"
-                                  title={settingsT("ampAdapterInstall")}
+                                  title={settingsT("copy")}
                                 />
                               </div>
                             </div>
@@ -1057,7 +1061,7 @@ export const SettingsDialog = () => {
                           className="size-4 text-foreground"
                         />
                       }
-                      installed={providerModels.amp.installed}
+                      installed={ampProviderUsable}
                       label="Amp"
                       loading={providerModels.amp.loading}
                       runtimeLabel="amp-acp"
@@ -1071,6 +1075,7 @@ export const SettingsDialog = () => {
                         ) : (
                           availableAmpModels.map((model) => {
                             const isSelected = ampModels.includes(model.id);
+                            const switchId = `amp-model-${encodeURIComponent(model.id)}`;
                             return (
                               <div
                                 className="flex items-center justify-between rounded-sm px-1.5 py-1 hover:bg-muted"
@@ -1083,11 +1088,13 @@ export const SettingsDialog = () => {
                                       ? "text-foreground"
                                       : "text-muted-foreground",
                                   )}
+                                  htmlFor={switchId}
                                 >
                                   {model.label}
                                 </Label>
                                 <Switch
                                   checked={isSelected}
+                                  id={switchId}
                                   onCheckedChange={(checked) => {
                                     if (checked !== isSelected) {
                                       toggleProviderModel(

--- a/src/components/ide/settings/settings-shared.tsx
+++ b/src/components/ide/settings/settings-shared.tsx
@@ -26,6 +26,7 @@ export const ProviderStatusCard = ({
   action,
   children,
   error,
+  help,
   icon,
   installed,
   label,
@@ -37,6 +38,7 @@ export const ProviderStatusCard = ({
   action?: ReactNode;
   children?: ReactNode;
   error: string | null;
+  help?: ReactNode;
   icon?: ReactNode;
   installed: boolean;
   label: string;
@@ -85,6 +87,8 @@ export const ProviderStatusCard = ({
           {statusMessage}
         </p>
       ) : null}
+
+      {help ? <div className="mt-3">{help}</div> : null}
 
       {children && installed ? (
         <div className="mt-4 max-h-[min(34vh,22rem)] overflow-y-auto pr-1">

--- a/src/components/ide/store/ide-store-types.ts
+++ b/src/components/ide/store/ide-store-types.ts
@@ -74,6 +74,7 @@ export interface IdeState {
     opencode: ProviderModelState;
     cursor: ProviderModelState;
     grok: ProviderModelState;
+    amp: ProviderModelState;
     fetchedAt: string | null;
   };
 

--- a/src/components/ide/store/provider-model-state.ts
+++ b/src/components/ide/store/provider-model-state.ts
@@ -12,6 +12,14 @@ import { dedupeModels, type ProviderModelsResponse } from "../ide-types";
 import type { IdeState } from "./ide-store-types";
 
 export const DEFAULT_PROVIDER_MODELS: IdeState["providerModels"] = {
+  amp: {
+    error: null,
+    installed: false,
+    loading: false,
+    models: [],
+    source: "unavailable",
+    version: null,
+  },
   anthropic: {
     error: null,
     installed: false,
@@ -109,6 +117,11 @@ export const toggleProviderModelInSettings = (
     });
   }
 
+  if (provider === "amp") {
+    const ampSelectedModels = updateModels(settings.ampSelectedModels);
+    return normalizeDefaultModelSettings({ ...settings, ampSelectedModels });
+  }
+
   const anthropicSelectedModels = updateModels(
     settings.anthropicSelectedModels,
   );
@@ -124,6 +137,19 @@ export const markProviderModelsLoading = (
   provider?: AiProvider,
 ): IdeState["providerModels"] => ({
   ...providerModels,
+  amp: {
+    ...providerModels.amp,
+    error:
+      provider === undefined || provider === "amp"
+        ? null
+        : providerModels.amp.error,
+    loading:
+      provider === undefined
+        ? true
+        : provider === "amp"
+          ? true
+          : providerModels.amp.loading,
+  },
   anthropic: {
     ...providerModels.anthropic,
     error:
@@ -195,6 +221,16 @@ export const getProviderModelsFromResponse = (
   payload: ProviderModelsResponse,
   previous: IdeState["providerModels"] = DEFAULT_PROVIDER_MODELS,
 ): IdeState["providerModels"] => {
+  const amp = payload.amp
+    ? {
+        error: payload.amp.error ?? null,
+        installed: payload.amp.installed,
+        loading: false,
+        models: dedupeModelOptions(payload.amp.models),
+        source: payload.amp.source,
+        version: payload.amp.version ?? null,
+      }
+    : previous.amp;
   const anthropic = payload.anthropic
     ? {
         error: payload.anthropic.error ?? null,
@@ -251,6 +287,7 @@ export const getProviderModelsFromResponse = (
     : previous.grok;
 
   return {
+    amp,
     anthropic,
     cursor,
     grok,
@@ -297,6 +334,7 @@ export const reconcileSettingsWithProviderModels = (
   );
   const cursorModelIds = providerModels.cursor.models.map((model) => model.id);
   const grokModelIds = providerModels.grok.models.map((model) => model.id);
+  const ampModelIds = providerModels.amp.models.map((model) => model.id);
   const openAiSelectedModels = reconcileProviderSelection(
     settings.openAiSelectedModels,
     openAiModelIds,
@@ -322,9 +360,15 @@ export const reconcileSettingsWithProviderModels = (
     grokModelIds,
     providerModels.grok,
   );
+  const ampSelectedModels = reconcileProviderSelection(
+    settings.ampSelectedModels,
+    ampModelIds,
+    providerModels.amp,
+  );
   const nextSettings = {
     ...settings,
     anthropicSelectedModels,
+    ampSelectedModels,
     cursorSelectedModels,
     grokSelectedModels,
     openCodeSelectedModels,
@@ -344,6 +388,7 @@ export const areSettingsSelectionsEqual = (a: AppSettings, b: AppSettings) =>
   a.openCodeSelectedModels.length === b.openCodeSelectedModels.length &&
   a.cursorSelectedModels.length === b.cursorSelectedModels.length &&
   a.grokSelectedModels.length === b.grokSelectedModels.length &&
+  a.ampSelectedModels.length === b.ampSelectedModels.length &&
   a.openAiSelectedModels.every(
     (model, index) => b.openAiSelectedModels[index] === model,
   ) &&
@@ -358,6 +403,9 @@ export const areSettingsSelectionsEqual = (a: AppSettings, b: AppSettings) =>
   ) &&
   a.grokSelectedModels.every(
     (model, index) => b.grokSelectedModels[index] === model,
+  ) &&
+  a.ampSelectedModels.every(
+    (model, index) => b.ampSelectedModels[index] === model,
   );
 
 export const getProviderModelsErrorState = (
@@ -365,6 +413,12 @@ export const getProviderModelsErrorState = (
   message: string,
   provider?: AiProvider,
 ): IdeState["providerModels"] => ({
+  amp: {
+    ...providerModels.amp,
+    error: provider && provider !== "amp" ? providerModels.amp.error : message,
+    loading:
+      provider && provider !== "amp" ? providerModels.amp.loading : false,
+  },
   anthropic: {
     ...providerModels.anthropic,
     error:

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Installieren oder aktualisieren",
     "ampAdapterPrerequisite": "Die Amp CLI muss ebenfalls installiert und mit amp login angemeldet sein.",
     "ampAdapterUpdateRequired": "amp-acp {version} ist veraltet. Installieren Sie amp-acp 0.9.0 oder neuer.",
+    "copy": "Kopieren",
     "archiveNow": "Jetzt archivieren",
     "archiveChatsAfterDays": "Chats archivieren nach",
     "archiveDays": "Tage bis zur Archivierung",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Agentenmodus",
+    "ampManagedPermissions": "Von Amp verwaltet",
     "askAnything": "Alles fragen...",
     "build": "Bauen",
     "buildAnything": "Alles bauen",
@@ -205,6 +206,11 @@
     "themeDescription": "Steuert das Oberflächen-Theme."
   },
   "settings": {
+    "ampAdapterDocs": "Adapter-Dokumentation",
+    "ampAdapterHelp": "Installieren Sie den Adapter amp-acp von tao12345666333. Der ähnlich benannte Adapter acp-amp ist mit dieser Integration nicht kompatibel.",
+    "ampAdapterInstall": "Installieren oder aktualisieren",
+    "ampAdapterPrerequisite": "Die Amp CLI muss ebenfalls installiert und mit amp login angemeldet sein.",
+    "ampAdapterUpdateRequired": "amp-acp {version} ist veraltet. Installieren Sie amp-acp 0.9.0 oder neuer.",
     "archiveNow": "Jetzt archivieren",
     "archiveChatsAfterDays": "Chats archivieren nach",
     "archiveDays": "Tage bis zur Archivierung",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Install or update",
     "ampAdapterPrerequisite": "The Amp CLI must also be installed and signed in with amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} is outdated. Install amp-acp 0.9.0 or newer.",
+    "copy": "Copy",
     "archiveNow": "Archive now",
     "archiveChatsAfterDays": "Archive chats after",
     "archiveDays": "Days before archiving",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Agent mode",
+    "ampManagedPermissions": "Managed by Amp",
     "askAnything": "Ask anything...",
     "build": "Build",
     "buildAnything": "Build anything",
@@ -205,6 +206,11 @@
     "themeDescription": "Controls the interface theme."
   },
   "settings": {
+    "ampAdapterDocs": "Adapter documentation",
+    "ampAdapterHelp": "Install the amp-acp adapter by tao12345666333. The similarly named acp-amp adapter is not compatible with this integration.",
+    "ampAdapterInstall": "Install or update",
+    "ampAdapterPrerequisite": "The Amp CLI must also be installed and signed in with amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} is outdated. Install amp-acp 0.9.0 or newer.",
     "archiveNow": "Archive now",
     "archiveChatsAfterDays": "Archive chats after",
     "archiveDays": "Days before archiving",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Modo de agente",
+    "ampManagedPermissions": "Gestionado por Amp",
     "askAnything": "Pregunta lo que quieras...",
     "build": "Construir",
     "buildAnything": "Construye cualquier cosa",
@@ -205,6 +206,11 @@
     "themeDescription": "Controla el tema de la interfaz."
   },
   "settings": {
+    "ampAdapterDocs": "Documentación del adaptador",
+    "ampAdapterHelp": "Instala el adaptador amp-acp de tao12345666333. El adaptador de nombre similar acp-amp no es compatible con esta integración.",
+    "ampAdapterInstall": "Instalar o actualizar",
+    "ampAdapterPrerequisite": "La CLI de Amp también debe estar instalada y haber iniciado sesión con amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} está desactualizado. Instala amp-acp 0.9.0 o posterior.",
     "archiveNow": "Archivar ahora",
     "archiveChatsAfterDays": "Archivar chats después de",
     "archiveDays": "Días antes de archivar",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Instalar o actualizar",
     "ampAdapterPrerequisite": "La CLI de Amp también debe estar instalada y haber iniciado sesión con amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} está desactualizado. Instala amp-acp 0.9.0 o posterior.",
+    "copy": "Copiar",
     "archiveNow": "Archivar ahora",
     "archiveChatsAfterDays": "Archivar chats después de",
     "archiveDays": "Días antes de archivar",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Installer ou mettre à jour",
     "ampAdapterPrerequisite": "La CLI Amp doit également être installée et connectée avec amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} est obsolète. Installez amp-acp 0.9.0 ou une version ultérieure.",
+    "copy": "Copier",
     "archiveNow": "Archiver maintenant",
     "archiveChatsAfterDays": "Archiver les chats après",
     "archiveDays": "Jours avant archivage",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Mode agent",
+    "ampManagedPermissions": "Géré par Amp",
     "askAnything": "Demandez n’importe quoi...",
     "build": "Construire",
     "buildAnything": "Construisez n’importe quoi",
@@ -205,6 +206,11 @@
     "themeDescription": "Contrôle le thème de l’interface."
   },
   "settings": {
+    "ampAdapterDocs": "Documentation de l’adaptateur",
+    "ampAdapterHelp": "Installez l’adaptateur amp-acp de tao12345666333. L’adaptateur au nom similaire acp-amp n’est pas compatible avec cette intégration.",
+    "ampAdapterInstall": "Installer ou mettre à jour",
+    "ampAdapterPrerequisite": "La CLI Amp doit également être installée et connectée avec amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} est obsolète. Installez amp-acp 0.9.0 ou une version ultérieure.",
     "archiveNow": "Archiver maintenant",
     "archiveChatsAfterDays": "Archiver les chats après",
     "archiveDays": "Jours avant archivage",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Installa o aggiorna",
     "ampAdapterPrerequisite": "Anche la CLI di Amp deve essere installata e autenticata con amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} non è aggiornato. Installa amp-acp 0.9.0 o versione successiva.",
+    "copy": "Copia",
     "archiveNow": "Archivia ora",
     "archiveChatsAfterDays": "Archivia le chat dopo",
     "archiveDays": "Giorni prima dell’archiviazione",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Modalità agente",
+    "ampManagedPermissions": "Gestito da Amp",
     "askAnything": "Chiedi qualsiasi cosa...",
     "build": "Costruisci",
     "buildAnything": "Costruisci qualsiasi cosa",
@@ -205,6 +206,11 @@
     "themeDescription": "Controlla il tema dell’interfaccia."
   },
   "settings": {
+    "ampAdapterDocs": "Documentazione dell’adattatore",
+    "ampAdapterHelp": "Installa l’adattatore amp-acp di tao12345666333. L’adattatore dal nome simile acp-amp non è compatibile con questa integrazione.",
+    "ampAdapterInstall": "Installa o aggiorna",
+    "ampAdapterPrerequisite": "Anche la CLI di Amp deve essere installata e autenticata con amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} non è aggiornato. Installa amp-acp 0.9.0 o versione successiva.",
     "archiveNow": "Archivia ora",
     "archiveChatsAfterDays": "Archivia le chat dopo",
     "archiveDays": "Giorni prima dell’archiviazione",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "インストールまたは更新",
     "ampAdapterPrerequisite": "Amp CLI もインストールし、amp login でログインしておく必要があります。",
     "ampAdapterUpdateRequired": "amp-acp {version} は古いため、amp-acp 0.9.0 以降をインストールしてください。",
+    "copy": "コピー",
     "archiveNow": "今すぐアーカイブ",
     "archiveChatsAfterDays": "指定日数後にチャットをアーカイブ",
     "archiveDays": "アーカイブまでの日数",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "エージェントモード",
+    "ampManagedPermissions": "Amp によって管理",
     "askAnything": "何でも質問...",
     "build": "ビルド",
     "buildAnything": "何でもビルド",
@@ -205,6 +206,11 @@
     "themeDescription": "インターフェイスのテーマを制御します。"
   },
   "settings": {
+    "ampAdapterDocs": "アダプターのドキュメント",
+    "ampAdapterHelp": "tao12345666333 による amp-acp アダプターをインストールしてください。名前が似ている acp-amp アダプターは、この統合とは互換性がありません。",
+    "ampAdapterInstall": "インストールまたは更新",
+    "ampAdapterPrerequisite": "Amp CLI もインストールし、amp login でログインしておく必要があります。",
+    "ampAdapterUpdateRequired": "amp-acp {version} は古いため、amp-acp 0.9.0 以降をインストールしてください。",
     "archiveNow": "今すぐアーカイブ",
     "archiveChatsAfterDays": "指定日数後にチャットをアーカイブ",
     "archiveDays": "アーカイブまでの日数",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "에이전트 모드",
+    "ampManagedPermissions": "Amp에서 관리",
     "askAnything": "무엇이든 물어보세요...",
     "build": "빌드",
     "buildAnything": "무엇이든 빌드",
@@ -205,6 +206,11 @@
     "themeDescription": "인터페이스 테마를 제어합니다."
   },
   "settings": {
+    "ampAdapterDocs": "어댑터 문서",
+    "ampAdapterHelp": "tao12345666333의 amp-acp 어댑터를 설치하세요. 이름이 비슷한 acp-amp 어댑터는 이 통합과 호환되지 않습니다.",
+    "ampAdapterInstall": "설치 또는 업데이트",
+    "ampAdapterPrerequisite": "Amp CLI도 설치하고 amp login으로 로그인해야 합니다.",
+    "ampAdapterUpdateRequired": "amp-acp {version}은 오래된 버전입니다. amp-acp 0.9.0 이상을 설치하세요.",
     "archiveNow": "지금 보관",
     "archiveChatsAfterDays": "다음 일수 후 채팅 보관",
     "archiveDays": "보관 전 일수",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "설치 또는 업데이트",
     "ampAdapterPrerequisite": "Amp CLI도 설치하고 amp login으로 로그인해야 합니다.",
     "ampAdapterUpdateRequired": "amp-acp {version}은 오래된 버전입니다. amp-acp 0.9.0 이상을 설치하세요.",
+    "copy": "복사",
     "archiveNow": "지금 보관",
     "archiveChatsAfterDays": "다음 일수 후 채팅 보관",
     "archiveDays": "보관 전 일수",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Instalar ou atualizar",
     "ampAdapterPrerequisite": "A CLI do Amp também deve estar instalada e autenticada com amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} está desatualizado. Instale amp-acp 0.9.0 ou posterior.",
+    "copy": "Copiar",
     "archiveNow": "Arquivar agora",
     "archiveChatsAfterDays": "Arquivar chats após",
     "archiveDays": "Dias antes de arquivar",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Modo do agente",
+    "ampManagedPermissions": "Gerido pelo Amp",
     "askAnything": "Pergunte qualquer coisa...",
     "build": "Construir",
     "buildAnything": "Construa qualquer coisa",
@@ -205,6 +206,11 @@
     "themeDescription": "Controla o tema da interface."
   },
   "settings": {
+    "ampAdapterDocs": "Documentação do adaptador",
+    "ampAdapterHelp": "Instale o adaptador amp-acp de tao12345666333. O adaptador de nome semelhante acp-amp não é compatível com esta integração.",
+    "ampAdapterInstall": "Instalar ou atualizar",
+    "ampAdapterPrerequisite": "A CLI do Amp também deve estar instalada e autenticada com amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} está desatualizado. Instale amp-acp 0.9.0 ou posterior.",
     "archiveNow": "Arquivar agora",
     "archiveChatsAfterDays": "Arquivar chats após",
     "archiveDays": "Dias antes de arquivar",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "Chế độ agent",
+    "ampManagedPermissions": "Do Amp quản lý",
     "askAnything": "Hỏi bất cứ điều gì...",
     "build": "Build",
     "buildAnything": "Build bất cứ thứ gì",
@@ -205,6 +206,11 @@
     "themeDescription": "Điều khiển chủ đề giao diện."
   },
   "settings": {
+    "ampAdapterDocs": "Tài liệu bộ chuyển đổi",
+    "ampAdapterHelp": "Hãy cài đặt bộ chuyển đổi amp-acp của tao12345666333. Bộ chuyển đổi có tên tương tự acp-amp không tương thích với tích hợp này.",
+    "ampAdapterInstall": "Cài đặt hoặc cập nhật",
+    "ampAdapterPrerequisite": "Amp CLI cũng phải được cài đặt và đăng nhập bằng amp login.",
+    "ampAdapterUpdateRequired": "amp-acp {version} đã cũ. Hãy cài đặt amp-acp 0.9.0 trở lên.",
     "archiveNow": "Lưu trữ ngay",
     "archiveChatsAfterDays": "Lưu trữ chat sau",
     "archiveDays": "Số ngày trước khi lưu trữ",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "Cài đặt hoặc cập nhật",
     "ampAdapterPrerequisite": "Amp CLI cũng phải được cài đặt và đăng nhập bằng amp login.",
     "ampAdapterUpdateRequired": "amp-acp {version} đã cũ. Hãy cài đặt amp-acp 0.9.0 trở lên.",
+    "copy": "Sao chép",
     "archiveNow": "Lưu trữ ngay",
     "archiveChatsAfterDays": "Lưu trữ chat sau",
     "archiveDays": "Số ngày trước khi lưu trữ",

--- a/src/i18n/messages/zh-Hans.json
+++ b/src/i18n/messages/zh-Hans.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "代理模式",
+    "ampManagedPermissions": "由 Amp 管理",
     "askAnything": "询问任何问题...",
     "build": "构建",
     "buildAnything": "构建任何东西",
@@ -205,6 +206,11 @@
     "themeDescription": "控制界面主题。"
   },
   "settings": {
+    "ampAdapterDocs": "适配器文档",
+    "ampAdapterHelp": "请安装 tao12345666333 提供的 amp-acp 适配器。名称相似的 acp-amp 适配器与此集成不兼容。",
+    "ampAdapterInstall": "安装或更新",
+    "ampAdapterPrerequisite": "还必须安装 Amp CLI，并通过 amp login 登录。",
+    "ampAdapterUpdateRequired": "amp-acp {version} 已过期。请安装 amp-acp 0.9.0 或更高版本。",
     "archiveNow": "立即归档",
     "archiveChatsAfterDays": "在以下天数后归档聊天",
     "archiveDays": "归档前的天数",

--- a/src/i18n/messages/zh-Hans.json
+++ b/src/i18n/messages/zh-Hans.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "安装或更新",
     "ampAdapterPrerequisite": "还必须安装 Amp CLI，并通过 amp login 登录。",
     "ampAdapterUpdateRequired": "amp-acp {version} 已过期。请安装 amp-acp 0.9.0 或更高版本。",
+    "copy": "复制",
     "archiveNow": "立即归档",
     "archiveChatsAfterDays": "在以下天数后归档聊天",
     "archiveDays": "归档前的天数",

--- a/src/i18n/messages/zh-Hant.json
+++ b/src/i18n/messages/zh-Hant.json
@@ -211,6 +211,7 @@
     "ampAdapterInstall": "安裝或更新",
     "ampAdapterPrerequisite": "還必須安裝 Amp CLI，並透過 amp login 登入。",
     "ampAdapterUpdateRequired": "amp-acp {version} 已過期。請安裝 amp-acp 0.9.0 或更新版本。",
+    "copy": "複製",
     "archiveNow": "立即封存",
     "archiveChatsAfterDays": "在以下天數後封存聊天",
     "archiveDays": "封存前的天數",

--- a/src/i18n/messages/zh-Hant.json
+++ b/src/i18n/messages/zh-Hant.json
@@ -131,6 +131,7 @@
   },
   "chat": {
     "agentMode": "代理模式",
+    "ampManagedPermissions": "由 Amp 管理",
     "askAnything": "詢問任何問題...",
     "build": "建置",
     "buildAnything": "建置任何東西",
@@ -205,6 +206,11 @@
     "themeDescription": "控制介面主題。"
   },
   "settings": {
+    "ampAdapterDocs": "介接器文件",
+    "ampAdapterHelp": "請安裝 tao12345666333 提供的 amp-acp 介接器。名稱相似的 acp-amp 介接器與此整合不相容。",
+    "ampAdapterInstall": "安裝或更新",
+    "ampAdapterPrerequisite": "還必須安裝 Amp CLI，並透過 amp login 登入。",
+    "ampAdapterUpdateRequired": "amp-acp {version} 已過期。請安裝 amp-acp 0.9.0 或更新版本。",
     "archiveNow": "立即封存",
     "archiveChatsAfterDays": "在以下天數後封存聊天",
     "archiveDays": "封存前的天數",

--- a/src/lib/ide-defaults.ts
+++ b/src/lib/ide-defaults.ts
@@ -24,6 +24,7 @@ export const ALL_PROVIDERS: AiProvider[] = [
   "opencode",
   "cursor",
   "grok",
+  "amp",
 ];
 export const CLAUDE_CODE_MODEL_IDS = {
   haiku: "haiku",
@@ -70,6 +71,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   groupToolCalls: false,
   cursorSelectedModels: [],
   grokSelectedModels: [],
+  ampSelectedModels: [],
   locale: "en",
   openAiSelectedModels: [],
   openCodeSelectedModels: [],
@@ -234,6 +236,10 @@ export const getModelsForProvider = (
 
   if (provider === "grok") {
     return clean(settings.grokSelectedModels);
+  }
+
+  if (provider === "amp") {
+    return clean(settings.ampSelectedModels);
   }
 
   return clean(settings.openAiSelectedModels);

--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -99,6 +99,7 @@ test("formatModelIdLabel formats provider-specific model ids", () => {
   );
   assert.equal(formatModelIdLabel("anthropic", "opus[1m]"), "Claude Opus 1M");
   assert.equal(formatModelIdLabel("anthropic", "sonnet"), "Claude Sonnet");
+  assert.equal(formatModelIdLabel("amp", "smart"), "Smart");
   assert.equal(formatModelIdLabel("openai", "   "), "");
 });
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -139,6 +139,12 @@ export const formatModelIdLabel = (
     return trimmed;
   }
 
+  if (provider === "amp") {
+    return parts
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
   if (provider === "openai" && parts[0]?.toLowerCase() === "gpt") {
     const [, version, ...rest] = parts;
     if (!version) {

--- a/src/types/ide.ts
+++ b/src/types/ide.ts
@@ -8,7 +8,8 @@ export type AiProvider =
   | "anthropic"
   | "opencode"
   | "cursor"
-  | "grok";
+  | "grok"
+  | "amp";
 export type AccentColor =
   | "black-white"
   | "red"
@@ -124,6 +125,7 @@ export interface AppSettings {
   openCodeSelectedModels: string[];
   cursorSelectedModels: string[];
   grokSelectedModels: string[];
+  ampSelectedModels: string[];
   locale: AppLocale;
   showReasoningSummaries: boolean;
   shellPath: string;


### PR DESCRIPTION
## Summary

- add Amp as a first-class Dream provider through the external `amp-acp` adapter
- discover Amp modes and supported reasoning efforts dynamically through ACP
- stream Amp messages, tool calls, file changes, commands, web results, and errors through Dream's existing UI
- support Amp for chat titles, commit messages, and pull request descriptions
- persist selected Amp modes in Dream's settings
- extract the existing Grok ACP implementation into a shared ACP transport
- document adapter installation and setup in every supported Dream language

## Setup

Amp requires the external [`amp-acp`](https://github.com/tao12345666333/amp-acp) adapter version 0.9.0 or newer:

```bash
npm install -g amp-acp@latest
amp login
```

The similarly named `acp-amp` executable is a different adapter and is not compatible with this integration.

The adapter is intentionally not bundled with Dream. Dream resolves `amp-acp` from the user's `PATH` and displays localized installation and update guidance in the provider settings.

## Permissions and security

- Dream's Full Access mode maps to the adapter's `bypass` permission option.
- Standard permissions remain managed by the user's Amp configuration.
- Dream's read-only Plan mode is not shown for Amp because `amp-acp` currently does not expose a reliable read-only mode.
- Background title and Git text generation run with an isolated temporary Amp settings file that disables all tools and MCP servers.
- The adapter identity and minimum supported version are validated on every launch.
- Unsupported or stale Amp modes fail explicitly instead of silently falling back to another mode.
- Amp sessions are not persisted because `amp-acp` does not currently expose session loading.

## ACP behavior

- Amp modes are discovered dynamically rather than hardcoded.
- Model ordering from the adapter is preserved.
- ACP shell, file, search, web, skill, and MCP calls are mapped to Dream's existing tool UI.
- JSON-encoded command envelopes are normalized without changing legitimate JSON file contents.
- Cancellation sends `session/cancel` before terminating the adapter.
- Grok continues to use its existing behavior through the extracted shared ACP transport.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 243 tests passed
- `pnpm vite:build`
- JavaScript syntax checks for changed Electron modules
- live model discovery with `amp-acp 0.9.0`
- live Amp title generation
- live no-tools verification for background generation
- manual Amp chat, tool output, title, persistence, and cancellation testing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dreamide/codesmith/dream/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788983682&installation_model_id=423091&pr_number=8&repository=dreamide%2Fdream&return_to=https%3A%2F%2Fgithub.com%2Fdreamide%2Fdream%2Fpull%2F8&signature=14af7d35d133bd019a29cef3fa53811d6f9f30c2caaccd7eb0358fce94c64960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Amp as a supported AI provider for chat, model selection, title generation, and Git actions.
  * Added Amp model discovery, selection, persistence, and provider-specific settings.
  * Added installation, authentication, version requirements, permissions, and adapter help in settings and documentation.
  * Added Amp-specific agent-mode behavior and provider icon support.
* **Bug Fixes**
  * Improved recognition and display of streamed commands, searches, file changes, and command output.
* **Documentation**
  * Documented Amp setup requirements and unsupported Plan mode.
* **Tests**
  * Added coverage for Amp configuration, model labels, streamed tool output, and legacy tool handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
